### PR TITLE
Feature: add  showResponseConfiguration parameter to search endpoint to show federated response times and called urls

### DIFF
--- a/src/main/java/org/semantics/apigateway/controller/GatewayController.java
+++ b/src/main/java/org/semantics/apigateway/controller/GatewayController.java
@@ -1,8 +1,6 @@
 package org.semantics.apigateway.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.apache.http.HttpStatus;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.lucene.queryparser.classic.ParseException;
@@ -53,7 +51,7 @@ public class GatewayController {
             query = "*";
         }
 
-        return searchService.performSearch(query + "*", allParams.get("database"), allParams.get("format"), "ols")
+        return searchService.performSearch(query + "*", allParams.get("database"), allParams.get("format"), "ols", false)
                 .<ResponseEntity<?>>thenApply(ResponseEntity::ok)
                 .exceptionally(e -> {
                     if (e.getCause() instanceof IllegalArgumentException) {

--- a/src/main/java/org/semantics/apigateway/controller/SearchController.java
+++ b/src/main/java/org/semantics/apigateway/controller/SearchController.java
@@ -43,10 +43,13 @@ public class SearchController {
             @RequestParam(required = false) Database database,
             @RequestParam(required = false) ResponseFormat format,
             @Parameter(description = "Transform the response result to a specific schema")
-            @RequestParam(required = false) TargetDbSchema targetDbSchema) {
+            @RequestParam(required = false) TargetDbSchema targetDbSchema,
+            @Parameter(description = "Display more details about the request results")
+            @RequestParam(required = false, defaultValue = "false") boolean showResponseConfiguration
+    ) {
 
 
-        return searchService.performSearch(query, database, format, targetDbSchema)
+        return searchService.performSearch(query, database, format, targetDbSchema, showResponseConfiguration)
                 .<ResponseEntity<?>>thenApply(ResponseEntity::ok)
                 .exceptionally(e -> {
                     if (e.getCause() instanceof IllegalArgumentException) {

--- a/src/main/java/org/semantics/apigateway/model/responses/AggregatedApiResponse.java
+++ b/src/main/java/org/semantics/apigateway/model/responses/AggregatedApiResponse.java
@@ -1,0 +1,69 @@
+package org.semantics.apigateway.model.responses;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@JsonSerialize(using = AggregatedApiResponse.CustomSerializer.class)
+public class AggregatedApiResponse {
+    private List<Map<String, Object>> collection = new ArrayList<>();
+    @JsonIgnore
+    private List<ApiResponse> originalResponses;
+    private boolean showConfig = false;
+
+    @JsonGetter
+    public Map<String, Object> responseConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("totalResponseTime", totalResponseTime());
+
+        config.put("databases", originalResponses.stream().map(x -> {
+            Map<String, Object> response = new HashMap<>();
+            response.put("url", x.getUrl());
+            response.put("status", x.getStatusCode());
+            response.put("responseTime", x.getResponseTime());
+            return response;
+        }));
+        return config;
+    }
+
+
+    public static class CustomSerializer extends JsonSerializer<AggregatedApiResponse> {
+        @Override
+        public void serialize(AggregatedApiResponse response, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+            if (!response.isShowConfig()) {
+                gen.writeStartArray();
+                for (Map<String, Object> item : response.getCollection()) {
+                    gen.writeObject(item);
+                }
+                gen.writeEndArray();
+            } else {
+                gen.writeStartObject();
+                gen.writeFieldName("collection");
+                gen.writeObject(response.getCollection());
+                if (response.responseConfig() != null) {
+                    gen.writeFieldName("responseConfig");
+                    gen.writeObject(response.responseConfig());
+                }
+                gen.writeEndObject();
+            }
+        }
+    }
+
+    public long totalResponseTime() {
+        return originalResponses.stream().map(ApiResponse::getResponseTime).reduce(0L, Long::sum);
+    }
+}

--- a/src/main/java/org/semantics/apigateway/model/responses/AggregatedResourceBody.java
+++ b/src/main/java/org/semantics/apigateway/model/responses/AggregatedResourceBody.java
@@ -1,0 +1,142 @@
+package org.semantics.apigateway.model.responses;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.semantics.apigateway.config.OntologyConfig;
+import org.semantics.apigateway.config.ResponseMapping;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class AggregatedResourceBody {
+    private String iri;
+    private String label;
+    private List<String> synonym;
+    private List<String> description;
+    @JsonProperty("short_form")
+    private String shortForm;
+    private String ontology;
+    private String type;
+    private String source;
+    @JsonProperty("backend_type")
+    private String backendType;
+
+    @JsonProperty("@context")
+    private String context;
+    @JsonProperty("@type")
+    private String typeURI;
+
+    public static AggregatedResourceBody fromMap(Map<String, Object> item, OntologyConfig config) throws RuntimeException {
+        AggregatedResourceBody newItem = new AggregatedResourceBody();
+        ResponseMapping responseMapping = config.getResponseMapping();
+
+        // Mapping fields based on the JSON configuration
+        try {
+            if (responseMapping.getIri() != null && item.containsKey(responseMapping.getIri())) {
+                newItem.setIri((String) item.get(responseMapping.getIri()));
+            }
+            if (responseMapping.getLabel() != null && item.containsKey(responseMapping.getLabel())) {
+                newItem.setLabel((String) item.get(responseMapping.getLabel()));
+            }
+            if (responseMapping.getSynonym() != null && item.containsKey(responseMapping.getSynonym())) {
+                Object label = item.get(responseMapping.getSynonym());
+                if (label instanceof List) {
+                    newItem.setSynonym((List<String>) label);
+                } else {
+                    newItem.setSynonym(List.of(label.toString()));
+                }
+            }
+
+            if (responseMapping.getShortForm() != null && item.containsKey(responseMapping.getShortForm())) {
+                newItem.setShortForm((String) item.get(responseMapping.getShortForm()));
+            } else if (newItem.getIri() != null) {
+                newItem.setShortForm(
+                        ResourceFactory.createResource(newItem.getIri()).getLocalName().toLowerCase());
+            }
+
+            if (responseMapping.getDescription() != null && item.containsKey(responseMapping.getDescription())) {
+                Object label = item.get(responseMapping.getDescription());
+                if (label instanceof List) {
+                    newItem.setDescription((List<String>) label);
+                } else {
+                    newItem.setDescription(List.of(label.toString()));
+                }
+            }
+            if (responseMapping.getOntology() != null && item.containsKey(responseMapping.getOntology())) {
+                if (responseMapping.getOntology().equals("links")) {
+                    Object keysObject = ((Map<?, ?>) item).get(responseMapping.getOntology());
+                    String ontologyItem = ((Map<?, String>) keysObject).get("ontology");
+                    newItem.setOntology(ResourceFactory.createResource(ontologyItem).getLocalName().toLowerCase());
+                } else {
+                    newItem.setOntology((String) item.get(responseMapping.getOntology()));
+                }
+            }
+            if (responseMapping.getType() != null && item.containsKey(responseMapping.getType())) {
+                if (config.getDatabase().equals("ontoportal")) {
+                    newItem.setType("class");
+                    // ontoportal do the search only on classes for now
+                } else if (config.getDatabase().equals("skosmos")) {
+                    newItem.setType("individual");
+                    // workaround ols type implementation that do not support skos types
+                } else {
+                    newItem.setType((String) item.get(responseMapping.getType()));
+                }
+            }
+
+            // Adding the source database as part of the new item
+            if (String.valueOf(config.getUrl()).contains("/search?")) {
+                newItem.setSource(String.valueOf(config.getUrl()).substring(0, String.valueOf(config.getUrl()).indexOf("/search?")));
+            } else if (String.valueOf(config.getUrl()).contains("/select?")) {
+                newItem.setSource(String.valueOf(config.getUrl()).substring(0, String.valueOf(config.getUrl()).indexOf("/select?")));
+            } else {
+                newItem.setSource(config.getUrl());
+            }
+
+            if (item.containsKey("@context")) {
+                newItem.setContext(item.get("@context").toString());
+            }
+
+            if (item.containsKey("@type")) {
+                newItem.setTypeURI(item.get("@type").toString());
+            }
+
+            // Adding the backend database type as part of the new item
+            newItem.setBackendType(config.getDatabase());
+
+        } catch (RuntimeException e) {
+            throw e;
+        }
+        // logger.info("Transformed item: {}", newItem);
+        return newItem;
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+
+        putIfNotEmpty(map, "iri", this.iri);
+        putIfNotEmpty(map, "label", this.label);
+        putIfNotEmpty(map, "synonym", this.synonym);
+        putIfNotEmpty(map, "description", this.description);
+        putIfNotEmpty(map, "short_form", this.shortForm);
+        putIfNotEmpty(map, "type", this.type);
+        putIfNotEmpty(map, "source", this.source);
+        putIfNotEmpty(map, "backend_type", this.backendType);
+        putIfNotEmpty(map, "ontology", this.ontology);
+
+        return map;
+    }
+
+
+    private void putIfNotEmpty(Map<String, Object> map, String key, Object value) {
+        if (value != null && !(value instanceof String && value.toString().isEmpty())) {
+            map.put(key, value);
+        }
+    }
+}

--- a/src/main/java/org/semantics/apigateway/model/responses/ApiResponse.java
+++ b/src/main/java/org/semantics/apigateway/model/responses/ApiResponse.java
@@ -1,0 +1,19 @@
+package org.semantics.apigateway.model.responses;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public  class ApiResponse {
+    private Map<String, Object> responseBody = new HashMap<>();
+    private int statusCode;
+    private long responseTime;
+    private String url;
+    private String name;
+}

--- a/src/main/java/org/semantics/apigateway/model/responses/TransformedApiResponse.java
+++ b/src/main/java/org/semantics/apigateway/model/responses/TransformedApiResponse.java
@@ -1,0 +1,22 @@
+package org.semantics.apigateway.model.responses;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public  class TransformedApiResponse {
+    private List<AggregatedResourceBody> collection = new ArrayList<>();
+    private ApiResponse originalResponse;
+
+    public List<Map<String, Object>> getCollection() {
+        return collection.stream().map(AggregatedResourceBody::toMap).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/org/semantics/apigateway/service/ResponseAggregatorService.java
+++ b/src/main/java/org/semantics/apigateway/service/ResponseAggregatorService.java
@@ -1,13 +1,13 @@
 package org.semantics.apigateway.service;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.jena.rdf.model.ResourceFactory;
 import org.semantics.apigateway.config.OntologyConfig;
-import org.semantics.apigateway.config.ResponseMapping;
+import org.semantics.apigateway.model.responses.ApiResponse;
+import org.semantics.apigateway.model.responses.TransformedApiResponse;
+import org.semantics.apigateway.model.responses.AggregatedResourceBody;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -18,16 +18,21 @@ public class ResponseAggregatorService {
     private static final Logger logger = LoggerFactory.getLogger(ResponseAggregatorService.class);
 
     // Method to dynamically transform a response based on the provided OntologyConfig
-    public List<Map<String, Object>> dynTransformResponse(Map<String, Object> response, OntologyConfig config) {
-        List<Map<String, Object>> result = new ArrayList<>();
+    public TransformedApiResponse dynTransformResponse(ApiResponse response, OntologyConfig config) {
+        TransformedApiResponse newResponse = new TransformedApiResponse();
+        List<AggregatedResourceBody> result = new ArrayList<>();
+
+
         if (response == null) {
             logger.error("Response is null");
-            return result;
+            return newResponse;
         }
+
+        newResponse.setOriginalResponse(response);
 
         // Extracting the nested JSON key from the response based on the configuration
         String nestedJsonKey = config.getResponseMapping().getNestedJson();
-        Object nestedData = response.getOrDefault(nestedJsonKey, new ArrayList<>());
+        Object nestedData = response.getResponseBody().getOrDefault(nestedJsonKey, new ArrayList<>());
         logger.debug("Nested JSON key: {}", nestedJsonKey);
         logger.debug("Nested data type: {}", nestedData.getClass().getSimpleName());
 
@@ -48,16 +53,19 @@ public class ResponseAggregatorService {
         }
 
         logger.debug("Transformed response: {}", result);
-        return result;
+
+        newResponse.setCollection(result);
+
+        return newResponse;
     }
 
     // Helper method to process a list of data items
-    private void processList(List<?> dataList, List<Map<String, Object>> result, OntologyConfig config) {
+    private void processList(List<?> dataList, List<AggregatedResourceBody> result, OntologyConfig config) {
         for (Object item : dataList) {
             if (item instanceof Map) {
                 // Processing each item in the list
-                Map<String, Object> newItem = processItem((Map<String, Object>) item, config);
-                if (!newItem.isEmpty()) {
+                AggregatedResourceBody newItem = processItem((Map<String, Object>) item, config);
+                if (newItem != null) {
                     result.add(newItem);
                 }
             }
@@ -65,75 +73,13 @@ public class ResponseAggregatorService {
     }
 
     // Method to process individual items in the response
-    private Map<String, Object> processItem(Map<String, Object> item, OntologyConfig config) {
-        Map<String, Object> newItem = new HashMap<>();
-        if (item == null) {
-            logger.error("Item is null");
-            return newItem;
-        }
-
-        ResponseMapping responseMapping = config.getResponseMapping();
-
-        // Mapping fields based on the JSON configuration
+    private AggregatedResourceBody processItem(Map<String, Object> item, OntologyConfig config) {
         try {
-            if (responseMapping.getIri() != null && item.containsKey(responseMapping.getIri())) {
-                newItem.put("iri", item.get(responseMapping.getIri()));
-            }
-            if (responseMapping.getLabel() != null && item.containsKey(responseMapping.getLabel())) {
-                newItem.put("label", item.get(responseMapping.getLabel()));
-            }
-            if (responseMapping.getSynonym() != null && item.containsKey(responseMapping.getSynonym())) {
-                newItem.put("synonym", item.get(responseMapping.getSynonym()));
-            }
-
-            if (responseMapping.getShortForm() != null && item.containsKey(responseMapping.getShortForm())) {
-                newItem.put("short_form", item.get(responseMapping.getShortForm()));
-            } else if (newItem.containsKey("iri") && newItem.get("iri") != null) {
-                newItem.put("short_form",
-                        ResourceFactory.createResource(String.valueOf(newItem.get("iri"))).getLocalName().toLowerCase());
-
-            }
-
-            if (responseMapping.getDescription() != null && item.containsKey(responseMapping.getDescription())) {
-                List<String> list = (List<String>) item.get(responseMapping.getDescription());
-                newItem.put("description", list);
-            }
-            if (responseMapping.getOntology() != null && item.containsKey(responseMapping.getOntology())) {
-                if (responseMapping.getOntology().equals("links")) {
-                    Object keysObject = ((Map<?, ?>) item).get(responseMapping.getOntology());
-                    String ontologyItem = ((Map<?, String>) keysObject).get("ontology");
-                    newItem.put("ontology", ResourceFactory.createResource(ontologyItem).getLocalName().toLowerCase());
-                } else {
-                    newItem.put("ontology", item.get(responseMapping.getOntology()));
-                }
-            }
-            if (responseMapping.getType() != null && item.containsKey(responseMapping.getType())) {
-                if (config.getDatabase().equals("ontoportal")) {
-                    newItem.put("type", "class"); // ontoportal do the search only on classes for now
-                } else if (config.getDatabase().equals("skosmos")) {
-                    newItem.put("type", "individual"); // workaround ols type implementation that do not support skos types
-                } else {
-                    newItem.put("type", item.get(responseMapping.getType()));
-                }
-            }
-
-            // Adding the source database as part of the new item
-            if (String.valueOf(config.getUrl()).contains("/search?")) {
-                newItem.put("source", String.valueOf(config.getUrl()).substring(0, String.valueOf(config.getUrl()).indexOf("/search?")));
-            } else if (String.valueOf(config.getUrl()).contains("/select?")) {
-                newItem.put("source", String.valueOf(config.getUrl()).substring(0, String.valueOf(config.getUrl()).indexOf("/select?")));
-            } else {
-                newItem.put("source", config.getUrl());
-            }
-
-            // Adding the backend database type as part of the new item
-            newItem.put("backend_type", config.getDatabase());
-
+            return AggregatedResourceBody.fromMap(item, config);
         } catch (Exception e) {
             logger.error("Error processing item: {}", e.getMessage(), e);
+            return null;
         }
-        // logger.info("Transformed item: {}", newItem);
-        return newItem;
     }
 
 

--- a/src/main/java/org/semantics/apigateway/service/search/SearchLocalIndexerService.java
+++ b/src/main/java/org/semantics/apigateway/service/search/SearchLocalIndexerService.java
@@ -100,7 +100,7 @@ public class SearchLocalIndexerService {
 
         for (Map<String, Object> result : combinedResults) {
             Document doc = new Document();
-            doc.add(new StringField("id", result.get("iri").toString() + "_" + result.get("ontology").toString(), Field.Store.YES));
+            doc.add(new StringField("id", result.get("iri").toString() + "_" + result.getOrDefault("ontology", "").toString(), Field.Store.YES));
             result.forEach((key, value) -> doc.add(new TextField(key, String.valueOf(value), Field.Store.YES)));
             w.addDocument(doc);
         }

--- a/src/test/java/org/semantics/apigateway/SearchServiceTest.java
+++ b/src/test/java/org/semantics/apigateway/SearchServiceTest.java
@@ -134,4 +134,15 @@ public class SearchServiceTest {
         assertThat(responseList).hasSize(100);
 
     }
+
+    @Test
+    public void testSearchJsonLdFormat() {
+        CompletableFuture<Object> r = searchService.performSearch("plant", "", "jsonld", "", false);
+
+        List<Map<String, Object>> response = (List<Map<String, Object>>) r.join();
+
+        Map<String, Object> firstPlant = response.get(0);
+        assertThat(firstPlant.containsKey("@type")).isTrue();
+        assertThat(firstPlant.containsKey("@context")).isTrue();
+    }
 }

--- a/src/test/java/org/semantics/apigateway/SearchServiceTest.java
+++ b/src/test/java/org/semantics/apigateway/SearchServiceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.semantics.apigateway.config.OntologyConfig;
+import org.semantics.apigateway.model.responses.AggregatedApiResponse;
 import org.semantics.apigateway.service.ConfigurationLoader;
 import org.semantics.apigateway.service.search.SearchService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,7 +51,7 @@ public class SearchServiceTest {
 
 
     @BeforeEach
-    public  void setup() {
+    public void setup() {
         searchService.getAccessor().setRestTemplate(restTemplate);
         List<OntologyConfig> configs = configurationLoader.getOntologyConfigs();
 
@@ -84,11 +85,13 @@ public class SearchServiceTest {
     }
 
     @Test
-    public void testSearchAllDatabases() throws IOException, ParseException {
-        CompletableFuture<Object> r = searchService.performSearch("plant", "", "", "");
+    public void testSearchAllDatabases() {
+        CompletableFuture<Object> r = searchService.performSearch("plant", "", "", "", false);
 
-        List<Map<String, Object>> responseList = (List<Map<String, Object>>) r.join();
+        AggregatedApiResponse response = (AggregatedApiResponse) r.join();
 
+        List<Map<String, Object>> responseList = response.getCollection();
+        
         assertThat(responseList).hasSize(100);
 
         Map<String, Object> firstPlant = responseList.get(0);
@@ -118,7 +121,7 @@ public class SearchServiceTest {
 
     @Test
     public void testSearchOlsSchema() throws IOException, ParseException {
-        CompletableFuture<Object> r = searchService.performSearch("plant", "", "", "ols");
+        CompletableFuture<Object> r = searchService.performSearch("plant", "", "", "ols", false);
 
         Map<String, Object> response = (Map<String, Object>) r.join();
 


### PR DESCRIPTION
Fix #18, by adding the optional parameter `showResponseConfiguration`, to display more details and debug the current request, see the example below:



![image](https://github.com/user-attachments/assets/5755b00c-722f-4f40-ba0a-345fe92f98b3)
