### PR TITLE
Feature: Enfroce jsonld by default and generate automaticly @context

### DIFF
--- a/src/main/java/org/semantics/apigateway/controller/ols/OlsSearchController.java
+++ b/src/main/java/org/semantics/apigateway/controller/ols/OlsSearchController.java
@@ -38,7 +38,7 @@ public class OlsSearchController {
             query = "*";
         }
 
-        return searchService.performSearch(query + "*", allParams.get("database"), allParams.get("format"), "ols", false);
+        return searchService.performSearch(query + "*", allParams.get("database"),  "ols", false);
     }
 
     @CrossOrigin

--- a/src/main/java/org/semantics/apigateway/model/CommonRequestParams.java
+++ b/src/main/java/org/semantics/apigateway/model/CommonRequestParams.java
@@ -27,6 +27,9 @@ public class CommonRequestParams {
     @QueryParam("showResponseConfiguration")
     private boolean showResponseConfiguration = false;
 
+    @QueryParam("displayEmptyValues")
+    private boolean displayEmptyValues = true;
+
     @QueryParam("disableCache")
     @Parameter(name = "disableCache", in = ParameterIn.QUERY, description = "Disable caching (not implemented yet)")
     private boolean disableCache = false;

--- a/src/main/java/org/semantics/apigateway/model/CommonRequestParams.java
+++ b/src/main/java/org/semantics/apigateway/model/CommonRequestParams.java
@@ -20,10 +20,6 @@ public class CommonRequestParams {
     )
     private String database = "";
 
-    @QueryParam("format")
-    @Parameter(name = "format", in = ParameterIn.QUERY, description = "Response format")
-    private ResponseFormat format;
-
     @QueryParam("targetDbSchema")
     @Parameter(name = "targetDbSchema", in = ParameterIn.QUERY, description = "Transform the response result to a specific schema")
     private TargetDbSchema targetDbSchema;

--- a/src/main/java/org/semantics/apigateway/model/CommonRequestParams.java
+++ b/src/main/java/org/semantics/apigateway/model/CommonRequestParams.java
@@ -8,6 +8,10 @@ import jakarta.ws.rs.QueryParam;
 import lombok.Data;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 
 @Data
 @Component
@@ -37,5 +41,15 @@ public class CommonRequestParams {
     @QueryParam("display")
     @Parameter(name = "display", in = ParameterIn.QUERY, description = "Choose the attribute to display in the results (coma seperated)",
             array = @ArraySchema(schema = @Schema(type = "string")))
-    private String display;
+    private String display = "";
+
+
+    public List<String> getDisplay() {
+        List<String> result = new ArrayList<>();
+//        result.add("iri"); // TODO remove this if the TSS no more use it and instead use the @id
+        if (display != null && !display.isEmpty()) {
+            result.addAll(Arrays.asList(display.split(",")));
+        }
+        return result;
+    }
 }

--- a/src/main/java/org/semantics/apigateway/model/ContextBaseUri.java
+++ b/src/main/java/org/semantics/apigateway/model/ContextBaseUri.java
@@ -1,0 +1,22 @@
+package org.semantics.apigateway.model;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to define the base URI for the JSON-LD context of a class.
+ * Example:
+ * \@ContextBaseUri("http://example.com/")
+ * public class MyClass {}
+ * \@ContextBaseUri("dct") will use the defined namespace dct: http://purl.org/dc/terms/
+ * public class MyClass {}
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ContextBaseUri {
+    String value();
+}
+
+

--- a/src/main/java/org/semantics/apigateway/model/ContextUri.java
+++ b/src/main/java/org/semantics/apigateway/model/ContextUri.java
@@ -1,0 +1,23 @@
+package org.semantics.apigateway.model;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to define the base URI for the JSON-LD context of a property.
+ * Example:
+ * public class MyClass {
+ *  \@ContextUri("http://example.com/name")
+ *  private String name;
+ *  \@ContextUri("dct/description")
+ *  private String description;
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface ContextUri {
+    String value();
+}
+
+

--- a/src/main/java/org/semantics/apigateway/model/RDFResource.java
+++ b/src/main/java/org/semantics/apigateway/model/RDFResource.java
@@ -5,47 +5,15 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.semantics.apigateway.model.responses.AggregatedResourceBody;
 
-import java.util.List;
-
 
 @EqualsAndHashCode(callSuper = true)
 @Data
+@ContextBaseUri("base4nfdi")
 public class RDFResource extends AggregatedResourceBody {
-    private String iri;
-    private String label;
-    private List<String> synonyms;
-    private List<String> descriptions;
-
-    @JsonProperty("short_form")
-    private String shortForm;
-
     private String ontology;
 
     @JsonProperty("ontology_iri")
     private String ontologyIri;
-
-
-    private String source;
-
-    @JsonProperty("source_name")
-    private String sourceName;
-
-    @JsonProperty("source_url")
-    private String sourceUrl;
-
-    @JsonProperty("backend_type")
-    private String backendType;
-
-    private String created;
-    private String modified;
-    private String version;
-
-
-    private String type;
-
-
-    private boolean obsolete;
-
 
     public String getTypeURI(){
         return "http://www.w3.org/2000/01/rdf-schema#Resource";

--- a/src/main/java/org/semantics/apigateway/model/RDFResource.java
+++ b/src/main/java/org/semantics/apigateway/model/RDFResource.java
@@ -45,4 +45,9 @@ public class RDFResource extends AggregatedResourceBody {
 
 
     private boolean obsolete;
+
+
+    public String getTypeURI(){
+        return "http://www.w3.org/2000/01/rdf-schema#Resource";
+    }
 }

--- a/src/main/java/org/semantics/apigateway/model/ResponseFormat.java
+++ b/src/main/java/org/semantics/apigateway/model/ResponseFormat.java
@@ -1,6 +1,0 @@
-package org.semantics.apigateway.model;
-
-public enum ResponseFormat {
-    json,
-    jsonld;
-}

--- a/src/main/java/org/semantics/apigateway/model/SemanticArtefact.java
+++ b/src/main/java/org/semantics/apigateway/model/SemanticArtefact.java
@@ -54,4 +54,9 @@ public class SemanticArtefact extends AggregatedResourceBody {
 
     //TODO use this instead of source in the future
     private List<String> includedInDataCatalog;
+
+    @Override
+    public String getTypeURI() {
+        return "https://w3id.org/mod#SemanticArtefact";
+    }
 }

--- a/src/main/java/org/semantics/apigateway/model/SemanticArtefact.java
+++ b/src/main/java/org/semantics/apigateway/model/SemanticArtefact.java
@@ -1,6 +1,5 @@
 package org.semantics.apigateway.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.semantics.apigateway.model.responses.AggregatedResourceBody;
@@ -13,11 +12,6 @@ public class SemanticArtefact extends AggregatedResourceBody {
     private String label;
     private List<String> synonyms;
     private List<String> descriptions;
-    private String ontology;
-    @JsonProperty("ontology_iri")
-    private String ontologyIri;
-    private String type;
-
 
     private String created;
     private String modified;

--- a/src/main/java/org/semantics/apigateway/model/SemanticArtefact.java
+++ b/src/main/java/org/semantics/apigateway/model/SemanticArtefact.java
@@ -8,45 +8,48 @@ import java.util.List;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
+@ContextBaseUri("dct")
 public class SemanticArtefact extends AggregatedResourceBody {
-    private String label;
-    private List<String> synonyms;
-    private List<String> descriptions;
 
-    private String created;
-    private String modified;
-    private String version;
-
-
-    private boolean obsolete;
-    private String status;
     private String versionIRI;
     private String accessRights;
     private String license;
     private String identifier;
-    private List<String> keywords;
-    private String landingPage;
     private List<String> language;
     private List<String> subject;
     private String accrualMethod;
     private String accrualPeriodicity;
-
     private List<String> bibliographicCitation;
-
-    private List<String> contactPoint;
     private List<String> creator;
     private List<String> contributor;
     private List<String> rightsHolder;
     private List<String> publisher;
-
     private String coverage;
     private String hasFormat;
+
+
+    @ContextUri("dcat")
+    private List<String> keywords;
+    @ContextUri("dcat")
+    private String landingPage;
+    @ContextUri("dcat")
+    private List<String> contactPoint;
+
+    @ContextUri("mod")
     private String competencyQuestion;
+    @ContextUri("mod")
     private String semanticArtefactRelation;
-    private List<String> createdWith;
+    @ContextUri("mod")
+    private String status;
+    @ContextUri("mod")
     private List<String> wasGeneratedBy;
 
+    @ContextUri("pav")
+    private List<String> createdWith;
+
+
     //TODO use this instead of source in the future
+    @ContextUri("schema")
     private List<String> includedInDataCatalog;
 
     @Override

--- a/src/main/java/org/semantics/apigateway/model/responses/AggregatedResourceBody.java
+++ b/src/main/java/org/semantics/apigateway/model/responses/AggregatedResourceBody.java
@@ -7,7 +7,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.semantics.apigateway.config.DatabaseConfig;
 import org.semantics.apigateway.config.ResponseMapping;
-import org.semantics.apigateway.model.ContextBaseUri;
 import org.semantics.apigateway.model.ContextUri;
 import org.semantics.apigateway.service.MappingTransformer;
 import org.slf4j.Logger;
@@ -21,7 +20,6 @@ import java.util.function.Consumer;
 @Setter
 @NoArgsConstructor
 public abstract class AggregatedResourceBody {
-    public final static String DEFAULT_BASE_URI = "http://base4nfdi.de/ts4nfdi/schema/";
     @JsonIgnore
     private final Logger logger = LoggerFactory.getLogger(AggregatedResourceBody.class);
     @JsonIgnore
@@ -177,6 +175,8 @@ public abstract class AggregatedResourceBody {
         }
         return shortForm;
     }
+
+
 
     public Map<String, Object> toMap(boolean includeOriginalBody, boolean displayEmpty) {
         Map<String, Object> map = new HashMap<>();

--- a/src/main/java/org/semantics/apigateway/model/responses/AggregatedResourceBody.java
+++ b/src/main/java/org/semantics/apigateway/model/responses/AggregatedResourceBody.java
@@ -39,13 +39,11 @@ public abstract class AggregatedResourceBody {
     @JsonProperty("source_url")
     protected String sourceUrl;
 
-    @JsonProperty("@context")
-    protected String context;
-    @JsonProperty("@type")
-    protected String typeURI;
-
     @JsonProperty("backend_type")
     protected String backendType;
+
+    // TODO after updating https://github.com/ts4nfdi/terminology-service-suite/blob/main/src/model/ts4nfdi-model/Ts4nfdiSearchResult.ts#L50C3-L50C20
+    private String type;
 
 
     private void setFieldValue(Object target, Field field, Object value) {
@@ -56,6 +54,7 @@ public abstract class AggregatedResourceBody {
         }
     }
 
+    public abstract String getTypeURI();
 
     public List<Field> getAllFields() {
         Field[] declaredFields = this.getClass().getDeclaredFields();
@@ -126,12 +125,6 @@ public abstract class AggregatedResourceBody {
         object.fillWithItem(item, responseMapping, localDataValues);
         object.setDefaultValues(config);
 
-        if (item.containsKey("@context")) {
-            object.setContext(item.get("@context").toString());
-        }
-        if (item.containsKey("@type")) {
-            object.setTypeURI(item.get("@type").toString());
-        }
 
         return object;
     }
@@ -139,19 +132,25 @@ public abstract class AggregatedResourceBody {
     public void setDefaultValues(DatabaseConfig config) {
         AggregatedResourceBody newItem = this;
         if (newItem.getShortForm() == null || newItem.getShortForm().isEmpty()) {
-            String iri = newItem.getIri();
-            if (iri.contains("#")) {
-                newItem.setShortForm(iri.substring(iri.lastIndexOf("#") + 1));
-            } else if (iri.contains("/")) {
-                newItem.setShortForm(iri.substring(iri.lastIndexOf("/") + 1));
-            } else {
-                newItem.setShortForm(newItem.getIri());
-            }
+            newItem.setShortForm(getShortFormDefault());
         }
 
         newItem.setSource(config.getUrl());
         newItem.setBackendType(config.getDatabase());
         newItem.setSourceName(config.getName());
+    }
+
+    private String getShortFormDefault() {
+        if (shortForm == null || shortForm.isEmpty()) {
+            if (iri.contains("#")) {
+                shortForm = iri.substring(iri.lastIndexOf("#") + 1);
+            } else if (iri.contains("/")) {
+                shortForm = iri.substring(iri.lastIndexOf("/") + 1);
+            } else {
+                shortForm = iri;
+            }
+        }
+        return shortForm;
     }
 
     public Map<String, Object> toMap(boolean includeOriginalBody, boolean displayEmpty) {

--- a/src/main/java/org/semantics/apigateway/model/responses/TransformedApiResponse.java
+++ b/src/main/java/org/semantics/apigateway/model/responses/TransformedApiResponse.java
@@ -18,7 +18,7 @@ public  class TransformedApiResponse {
     private boolean paginate;
     private ApiResponse originalResponse;
 
-    public List<Map<String, Object>> getCollection(boolean showOriginalResponse) {
-        return collection.stream().map(x -> x.toMap(showOriginalResponse, true)).toList();
+    public List<Map<String, Object>> getCollection(boolean showOriginalResponse, boolean displayEmpty) {
+        return collection.stream().map(x -> x.toMap(showOriginalResponse, displayEmpty)).toList();
     }
 }

--- a/src/main/java/org/semantics/apigateway/service/AbstractEndpointService.java
+++ b/src/main/java/org/semantics/apigateway/service/AbstractEndpointService.java
@@ -119,8 +119,9 @@ public abstract class AbstractEndpointService {
         String type = "";
         Map<String, String> context = new HashMap<>();
         try {
-            type = this.dynTransformResponse.getClazz().getDeclaredConstructor().newInstance().getTypeURI();
-            context = this.dynTransformResponse.getClazz().getDeclaredConstructor().newInstance().generateContext(commonRequestParams.getDisplay());
+            Class<? extends AggregatedResourceBody> clazz = this.dynTransformResponse.getClazz();
+            type = jsonLdTransform.getTypeURI(clazz);
+            context = jsonLdTransform.generateContext(clazz, commonRequestParams.getDisplay());
         } catch (Exception e) {
             logger.error("Error transforming json Ld", e);
         }

--- a/src/main/java/org/semantics/apigateway/service/JsonLdTransform.java
+++ b/src/main/java/org/semantics/apigateway/service/JsonLdTransform.java
@@ -1,28 +1,112 @@
 package org.semantics.apigateway.service;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.semantics.apigateway.model.ContextBaseUri;
+import org.semantics.apigateway.model.ContextUri;
+import org.semantics.apigateway.model.responses.AggregatedResourceBody;
 import org.springframework.stereotype.Service;
 
+import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+
 @Service
 public class JsonLdTransform {
+    public final static String DEFAULT_BASE_URI = "http://base4nfdi.de/ts4nfdi/schema/";
 
-    public List<Map<String, Object>> convertToJsonLd(List<Map<String, Object>> response, String type) {
-        Map<String, Object> context = new HashMap<>();
-        context.put("@vocab", "http://base4nfdi.de/ts4nfdi/schema/");
-        context.put("ts", "http://base4nfdi.de/ts4nfdi/schema/");
+    public List<Map<String, Object>> convertToJsonLd(List<Map<String, Object>> response, String type, Map<String, String> context) {
 
         List<Map<String, Object>> nestedData = response;
 
         nestedData = nestedData.stream().peek(item -> {
             item.put("@context", context);
-            item.put("@type", type);
+            item.put("@type", type); // TODO: make this a list
             item.put("@id", item.get("iri"));
         }).collect(Collectors.toList());
 
         return nestedData;
+    }
+
+    public Map<String, String> getNameSpaceMap() {
+        return Map.of(
+                "skos", "http://www.w3.org/2004/02/skos/core#",
+                "dct", "http://purl.org/dc/terms/",
+                "mod", "https://w3id.org/mod#",
+                "owl", "http://www.w3.org/2002/07/owl#",
+                "dcat", "http://www.w3.org/ns/dcat#",
+                "pav", "http://purl.org/pav/",
+                "schema", "http://schema.org/",
+                "base4nfdi", "http://base4nfdi.de/ts4nfdi/schema/"
+        );
+    }
+
+
+    public String getBaseUri() {
+        ContextBaseUri baseUri = getClass().getAnnotation(ContextBaseUri.class);
+        String baseUriString = DEFAULT_BASE_URI;
+        if (baseUri != null) {
+            baseUriString = getNameSpaceMap().getOrDefault(baseUri.value(), baseUri.value());
+        }
+        return baseUriString;
+    }
+
+    public String getTypeURI(Class<? extends AggregatedResourceBody> clazz) {
+        AggregatedResourceBody instance;
+        try {
+            instance = clazz.getDeclaredConstructor().newInstance();
+        } catch (Exception e) {
+            return null;
+        }
+        return instance.getTypeURI();
+    }
+
+    public Map<String, String> generateContext(Class<? extends AggregatedResourceBody> clazz, List<String> displayFields) {
+        AggregatedResourceBody instance;
+        try {
+            instance = clazz.getDeclaredConstructor().newInstance();
+        } catch (Exception e) {
+            return null;
+        }
+
+        Map<String, String> namespaceMap = getNameSpaceMap();
+        Map<String, String> contextMap = new HashMap<>();
+        String baseUriString = getBaseUri();
+
+        contextMap.put("@base", baseUriString);
+
+        for (Field field : instance.getAllFields()) {
+            String fullUri;
+            JsonProperty jsonProperty = field.getAnnotation(JsonProperty.class);
+            String fieldName = jsonProperty != null ? jsonProperty.value() : field.getName();
+
+            if (displayFields != null && !displayFields.isEmpty() && !displayFields.contains(field.getName()))
+                continue;
+
+            if (field.isAnnotationPresent(ContextUri.class)) {
+                ContextUri annotation = field.getAnnotation(ContextUri.class);
+                String uri = annotation.value();
+                String[] uris = uri.split(":");
+                fullUri = uri;
+                if (uris.length > 1) {
+                    String prefix = uris[0];
+                    String namespace = namespaceMap.get(prefix);
+                    if (namespace != null) {
+                        fullUri = namespace + uris[1];
+                    }
+                } else {
+                    String namespace = namespaceMap.get(uri);
+                    if (namespace != null)
+                        fullUri = namespace + fieldName;
+                }
+
+            } else {
+                fullUri = baseUriString + fieldName;
+            }
+            contextMap.put(fieldName, fullUri);
+        }
+        return contextMap;
     }
 }

--- a/src/main/java/org/semantics/apigateway/service/JsonLdTransform.java
+++ b/src/main/java/org/semantics/apigateway/service/JsonLdTransform.java
@@ -1,14 +1,7 @@
 package org.semantics.apigateway.service;
 
-import com.github.jsonldjava.utils.JsonUtils;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.riot.Lang;
-import org.apache.jena.riot.RDFDataMgr;
 import org.springframework.stereotype.Service;
 
-import java.io.StringReader;
-import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -17,50 +10,19 @@ import java.util.stream.Collectors;
 @Service
 public class JsonLdTransform {
 
-    public boolean isJsonLdFormat(String format) {
-        return "jsonld".equalsIgnoreCase(format);
-    }
-
-    public List<Map<String, Object>> convertToJsonLd(List<Map<String, Object>> response) {
+    public List<Map<String, Object>> convertToJsonLd(List<Map<String, Object>> response, String type) {
         Map<String, Object> context = new HashMap<>();
         context.put("@vocab", "http://base4nfdi.de/ts4nfdi/schema/");
         context.put("ts", "http://base4nfdi.de/ts4nfdi/schema/");
-        String type = "ts:Resource";
 
-        List<Map<String,Object>> nestedData = response;
+        List<Map<String, Object>> nestedData = response;
 
-        nestedData = nestedData.stream().map(item -> {
-            try {
-                Map<String, Object> jsonLd = new HashMap<>();
-                jsonLd.put("@context", context);
-                jsonLd.put("@type", type);
-
-                for (Map.Entry<String, Object> entry : item.entrySet()) {
-                    String key = entry.getKey();
-                    Object value = entry.getValue();
-                    jsonLd.put(key, value);
-                }
-
-                String jsonString = JsonUtils.toString(jsonLd);
-                if (jsonString != null) {
-                    String jsonLdString = convertJsonToJsonLd(jsonString);
-                    return (Map<String, Object>) JsonUtils.fromString(jsonLdString);
-                }
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-            return null;
+        nestedData = nestedData.stream().peek(item -> {
+            item.put("@context", context);
+            item.put("@type", type);
+            item.put("@id", item.get("iri"));
         }).collect(Collectors.toList());
 
         return nestedData;
-    }
-
-    public static String convertJsonToJsonLd(String json) {
-        Model model = ModelFactory.createDefaultModel();
-        RDFDataMgr.read(model, new StringReader(json), null, Lang.JSONLD);
-
-        StringWriter out = new StringWriter();
-        RDFDataMgr.write(out, model, Lang.JSONLD);
-        return out.toString();
     }
 }

--- a/src/main/java/org/semantics/apigateway/service/JsonLdTransform.java
+++ b/src/main/java/org/semantics/apigateway/service/JsonLdTransform.java
@@ -24,7 +24,9 @@ public class JsonLdTransform {
         nestedData = nestedData.stream().peek(item -> {
             item.put("@context", context);
             item.put("@type", type); // TODO: make this a list
-            item.put("@id", item.get("iri"));
+            if(item.get("iri") != null){
+                item.put("@id", item.get("iri"));
+            }
         }).collect(Collectors.toList());
 
         return nestedData;

--- a/src/main/java/org/semantics/apigateway/service/artefacts/ArtefactsService.java
+++ b/src/main/java/org/semantics/apigateway/service/artefacts/ArtefactsService.java
@@ -36,7 +36,7 @@ public class ArtefactsService extends AbstractEndpointService {
         try {
             return
                     findAllArtefacts(params, collectionId, currentUser, accessor)
-                            .thenApply(this::transformJsonLd)
+                            .thenApply(data -> transformJsonLd(data, params))
                             .thenApply(data -> transformForTargetDbSchema(data, params.getTargetDbSchema(), endpoint)).get();
         } catch (InterruptedException | ExecutionException e) {
             logger.error(e.getMessage(), e);
@@ -54,7 +54,7 @@ public class ArtefactsService extends AbstractEndpointService {
         String endpoint = "resources";
         return findAllArtefacts(params, null, null, accessor)
                 .thenApply(data -> filterOutByQuery(query, data))
-                .thenApply(this::transformJsonLd)
+                .thenApply(x -> transformJsonLd(x, params))
                 .thenApply(data -> transformForTargetDbSchema(data, params.getTargetDbSchema(), endpoint));
     }
 

--- a/src/main/java/org/semantics/apigateway/service/artefacts/ArtefactsService.java
+++ b/src/main/java/org/semantics/apigateway/service/artefacts/ArtefactsService.java
@@ -36,7 +36,7 @@ public class ArtefactsService extends AbstractEndpointService {
         try {
             return
                     findAllArtefacts(params, collectionId, currentUser, accessor)
-                            .thenApply(data -> transformJsonLd(data, params.getFormat()))
+                            .thenApply(this::transformJsonLd)
                             .thenApply(data -> transformForTargetDbSchema(data, params.getTargetDbSchema(), endpoint)).get();
         } catch (InterruptedException | ExecutionException e) {
             logger.error(e.getMessage(), e);
@@ -54,7 +54,7 @@ public class ArtefactsService extends AbstractEndpointService {
         String endpoint = "resources";
         return findAllArtefacts(params, null, null, accessor)
                 .thenApply(data -> filterOutByQuery(query, data))
-                .thenApply(data -> transformJsonLd(data, params.getFormat()))
+                .thenApply(this::transformJsonLd)
                 .thenApply(data -> transformForTargetDbSchema(data, params.getTargetDbSchema(), endpoint));
     }
 
@@ -85,14 +85,13 @@ public class ArtefactsService extends AbstractEndpointService {
     private CompletableFuture<AggregatedApiResponse> findAllArtefacts(CommonRequestParams params, String collectionId, User currentUser, ApiAccessor accessor) {
         String endpoint = "resources";
         String database = params.getDatabase();
-        boolean showResponseConfiguration = params.isShowResponseConfiguration();
 
         accessor = initAccessor(database, endpoint, accessor);
         TerminologyCollection collection = collectionService.getCurrentUserCollection(collectionId, currentUser);
 
         return accessor.get()
                 .thenApply(data -> this.transformApiResponses(data, endpoint))
-                .thenApply(transformedData -> flattenResponseList(transformedData, showResponseConfiguration, collection))
+                .thenApply(transformedData -> flattenResponseList(transformedData, params, collection))
                 .thenApply(data -> filterOutByCollection(collection, data));
     }
 }

--- a/src/main/java/org/semantics/apigateway/service/search/SearchService.java
+++ b/src/main/java/org/semantics/apigateway/service/search/SearchService.java
@@ -21,7 +21,6 @@ import org.springframework.stereotype.Service;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 
 
 @Service
@@ -68,9 +67,10 @@ public class SearchService extends AbstractEndpointService {
                     .thenApply(data -> filterOutByTerminologies(terminologies, data))
                     .thenApply(data -> filterOutByCollection(collection, data))
                     .thenApply(data -> reIndexResults(query, data))
-                    .thenApply(this::transformJsonLd)
+                    .thenApply(x -> transformJsonLd(x, params))
                     .thenApply(data -> transformForTargetDbSchema(data, targetDbSchema, endpoint)).get();
-        } catch (InterruptedException | ExecutionException e) {
+        } catch (Exception e) {
+            logger.error(e.getMessage(), e);
             return null;
         }
     }

--- a/src/main/resources/backend_types/gnd.yml
+++ b/src/main/resources/backend_types/gnd.yml
@@ -27,7 +27,7 @@ models:
     iri: id
     ontology: ontology_name
     synonyms: variantName
-    descriptions: biographicalOrHistoricalInformation
+    descriptions: biographicalOrHistoricalInformation|professionOrOccupation->label|firstComposer->label|organizerOrHost->label
     shortForm: gndIdentifier
     sourceUrl: id
     type: type

--- a/src/test/java/org/semantics/apigateway/ArtefactDataServiceTest.java
+++ b/src/test/java/org/semantics/apigateway/ArtefactDataServiceTest.java
@@ -22,11 +22,6 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
     @Autowired
     private ArtefactsDataService artefactsService;
 
-    public ArtefactDataServiceTest() {
-        super();
-        this.responseClass = RDFResource.class;
-    }
-
     @BeforeEach
     public void setupClass() {
         this.responseClass = RDFResource.class;

--- a/src/test/java/org/semantics/apigateway/ArtefactDataServiceTest.java
+++ b/src/test/java/org/semantics/apigateway/ArtefactDataServiceTest.java
@@ -1,7 +1,9 @@
 package org.semantics.apigateway;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.semantics.apigateway.model.CommonRequestParams;
+import org.semantics.apigateway.model.RDFResource;
 import org.semantics.apigateway.model.responses.AggregatedApiResponse;
 import org.semantics.apigateway.service.artefacts.ArtefactsDataService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +21,16 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
 
     @Autowired
     private ArtefactsDataService artefactsService;
+
+    public ArtefactDataServiceTest() {
+        super();
+        this.responseClass = RDFResource.class;
+    }
+
+    @BeforeEach
+    public void setupClass() {
+        this.responseClass = RDFResource.class;
+    }
 
     @Test
     public void testGetTerm() {
@@ -103,17 +115,18 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
         assertMapEquality(response, createOntoPortalInraeScheme());
     }
 
-    private Map<String,Object> createOls2NCBITaxonPropertyFixture(){
-        Map<String,Object> map = createOlsNCBITaxonPropertyFixture();
+    private Map<String, Object> createOls2NCBITaxonPropertyFixture() {
+        Map<String, Object> map = createOlsNCBITaxonPropertyFixture();
         map.put("backend_type", "ols2");
         map.put("source", "https://www.ebi.ac.uk/ols4/api/v2");
         map.put("source_name", "ebi");
-        map.put("type", "property");
+//        map.put("type", "property");
         map.put("source_url", null); //TODO: add source_url
         return map;
     }
-    private Map<String,Object> createOlsNCBITaxonPropertyFixture(){
-        Map<String,Object> map = new HashMap<>();
+
+    private Map<String, Object> createOlsNCBITaxonPropertyFixture() {
+        Map<String, Object> map = new HashMap<>();
         map.put("iri", "http://purl.obolibrary.org/obo/ncbitaxon#has_rank");
         map.put("backend_type", "ols");
         map.put("synonyms", Collections.emptyList());
@@ -121,7 +134,7 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
         map.put("obsolete", false);
         map.put("source", "https://semanticlookup.zbmed.de/ols/api");
         map.put("label", "has_rank");
-        map.put("type", null);
+//        map.put("type", null);
         map.put("descriptions", List.of("A metadata relation between a class and its taxonomic rank (eg species, family)",
                 "This is an abstract class for use with the NCBI taxonomy to name the depth of the node within the tree. The link between the node term and the rank is only visible if you are using an obo 1.3 aware browser/editor; otherwise this can be ignored"));
         map.put("version", null);
@@ -134,17 +147,17 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
         return map;
     }
 
-    private Map<String,Object> createOls2NCBITaxonFixture(){
-        Map<String,Object> map = createNCBITaxonFixture();
+    private Map<String, Object> createOls2NCBITaxonFixture() {
+        Map<String, Object> map = createNCBITaxonFixture();
         map.put("backend_type", "ols2");
         map.put("source", "https://www.ebi.ac.uk/ols4/api/v2");
         map.put("source_name", "ebi");
-        map.put("type", "class");
+//        map.put("type", "class");
         map.put("source_url", null); //TODO: add source_url
         return map;
     }
 
-    private Map<String, Object> createNCBITaxonFixture(){
+    private Map<String, Object> createNCBITaxonFixture() {
         Map<String, Object> result = new HashMap<>();
         result.put("iri", "http://purl.obolibrary.org/obo/NCBITaxon_2");
         result.put("backend_type", "ols");
@@ -163,7 +176,7 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
         result.put("obsolete", false);
         result.put("source", "https://semanticlookup.zbmed.de/ols/api");
         result.put("label", "Bacteria");
-        result.put("type", null); //TODO: fix this
+//        result.put("type", null); //TODO: fix this
         result.put("descriptions", Collections.emptyList());
         result.put("version", null);
         result.put("source_url", "https://semanticlookup.zbmed.de/ols/api/ontologies/ncbitaxon/terms/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FNCBITaxon_2?lang=en");
@@ -184,7 +197,7 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
         map.put("descriptions", List.of("A summary of the resource."));
         map.put("obsolete", false);
         map.put("source", "https://data.agroportal.lirmm.fr");
-        map.put("type", "http://www.w3.org/2002/07/owl#AnnotationProperty");
+//        map.put("type", "http://www.w3.org/2002/07/owl#AnnotationProperty");
         map.put("version", null); //TODO: to remove maybe
         map.put("source_url", null); //TODO: add source_url
         map.put("short_form", "abstract");
@@ -203,17 +216,14 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
         fixture.put("label", "activities");
         fixture.put("source", "https://agrovoc.fao.org/browse/rest/v1");
         fixture.put("source_name", "agrovoc");
-//        fixture.put("ontology", "agrovoc");
-//        fixture.put("descriptions", List.of("AGROVOC Multilingual Thesaurus"));
         fixture.put("synonyms", Collections.emptyList());
-        fixture.put("descriptions", null); //TODO: should be empty array
+        fixture.put("descriptions", null); //TODO: should be empty array or not empty
         fixture.put("created", null);
         fixture.put("modified", null);
         fixture.put("obsolete", false);
         fixture.put("source_url", null);
         fixture.put("version", null);
         fixture.put("ontology_iri", null); //TODO: fix this
-        fixture.put("type", null); // TODO implement default value logic
         fixture.put("short_form", "c_330834");
         fixture.put("ontology", null);
         return fixture;
@@ -236,7 +246,7 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
         fixture.put("source_url", "http://agroportal.lirmm.fr/ontologies/AGROVOC?p=classes&conceptid=http%3A%2F%2Faims.fao.org%2Faos%2Fagrovoc%2Fc_330834");
         fixture.put("version", null);
         fixture.put("ontology_iri", null); //TODO: fix this
-        fixture.put("type", "http://www.w3.org/2004/02/skos/core#Concept"); // TODO implement default value logic
+//        fixture.put("type", "http://www.w3.org/2004/02/skos/core#Concept"); // TODO implement default value logic
         return fixture;
     }
 
@@ -251,7 +261,7 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
         fixture.put("ontology", "https://data.agroportal.lirmm.fr/ontologies/INRAETHES");
         fixture.put("descriptions", Collections.emptyList());
         fixture.put("synonyms", Collections.emptyList());
-        fixture.put("type", "http://www.w3.org/2004/02/skos/core#Collection");
+//        fixture.put("type", "http://www.w3.org/2004/02/skos/core#Collection");
         fixture.put("created", null);
         fixture.put("modified", null);
         fixture.put("obsolete", false);
@@ -266,7 +276,7 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
         fixture.put("backend_type", "ols");
         fixture.put("source_name", "zbmed");
         fixture.put("source", "https://semanticlookup.zbmed.de/ols/api");
-        fixture.put("type", null); //TODO: fix this
+//        fixture.put("type", null); //TODO: fix this
         fixture.put("descriptions", List.of("LanguaL curation note: US FDA 1995 Code:  QR"));
         fixture.put("source_url", "https://semanticlookup.zbmed.de/ols/api/ontologies/foodon/individuals/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FGAZ_00000464?lang=en");
         return fixture;
@@ -278,7 +288,7 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
         fixture.put("source", "https://www.ebi.ac.uk/ols4/api/v2");
         fixture.put("source_name", "ebi");
         fixture.put("ontology", "foodon");
-        fixture.put("type", "individual");
+//        fixture.put("type", "individual");
         fixture.put("descriptions", List.of("LanguaL curation note: US FDA 1995 Code:  QR"));
         fixture.put("ontology_iri", "http://purl.obolibrary.org/obo/foodon.owl");
         return fixture;
@@ -290,7 +300,7 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
         fixture.put("source", "https://data.agroportal.lirmm.fr");
         fixture.put("source_name", "agroportal");
         fixture.put("ontology", null); //TODO: fix this
-        fixture.put("type", "http://www.w3.org/2002/07/owl#NamedIndividual"); //TODO: harmonize with ols types
+//        fixture.put("type", "http://www.w3.org/2002/07/owl#NamedIndividual"); //TODO: harmonize with ols types
         return fixture;
     }
 
@@ -321,7 +331,7 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
         fixture.put("created", null);
         fixture.put("obsolete", false);
         fixture.put("source", "https://data.agroportal.lirmm.fr");
-        fixture.put("type", "http://www.w3.org/2004/02/skos/core#ConceptScheme");
+//        fixture.put("type", "http://www.w3.org/2004/02/skos/core#ConceptScheme");
         fixture.put("descriptions", Collections.emptyList());
         fixture.put("version", null);
         fixture.put("source_url", null);
@@ -333,7 +343,7 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
         return fixture;
     }
 
-    private Map<String, Object> createGndTermFixture(){
+    private Map<String, Object> createGndTermFixture() {
         Map<String, Object> fixture = new HashMap<>();
         fixture.put("iri", "https://d-nb.info/gnd/4074335-4");
         fixture.put("backend_type", "gnd");
@@ -341,7 +351,7 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
         fixture.put("obsolete", false);
         fixture.put("source", "https://lobid.org");
         fixture.put("label", "London");
-        fixture.put("type", "AuthorityResource");
+//        fixture.put("type", "AuthorityResource");
         fixture.put("descriptions", List.of("Hauptstadt des Vereinigten Königreichs von Großbritannien und Nordirland, in Mittelsteinzeit besiedelt, 43 n. Chr. von Römern gegründet; das County of London war 1889-1965 Verwaltungsgrafschaft u. zeremonielle Grafschaft"));
         fixture.put("version", null);
         fixture.put("source_url", "https://d-nb.info/gnd/4074335-4");

--- a/src/test/java/org/semantics/apigateway/ArtefactDataServiceTest.java
+++ b/src/test/java/org/semantics/apigateway/ArtefactDataServiceTest.java
@@ -120,7 +120,7 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
         map.put("backend_type", "ols2");
         map.put("source", "https://www.ebi.ac.uk/ols4/api/v2");
         map.put("source_name", "ebi");
-//        map.put("type", "property");
+        map.put("type", "property");
         map.put("source_url", null); //TODO: add source_url
         return map;
     }
@@ -134,7 +134,7 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
         map.put("obsolete", false);
         map.put("source", "https://semanticlookup.zbmed.de/ols/api");
         map.put("label", "has_rank");
-//        map.put("type", null);
+        map.put("type", null); // TODO: fix this
         map.put("descriptions", List.of("A metadata relation between a class and its taxonomic rank (eg species, family)",
                 "This is an abstract class for use with the NCBI taxonomy to name the depth of the node within the tree. The link between the node term and the rank is only visible if you are using an obo 1.3 aware browser/editor; otherwise this can be ignored"));
         map.put("version", null);
@@ -152,7 +152,7 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
         map.put("backend_type", "ols2");
         map.put("source", "https://www.ebi.ac.uk/ols4/api/v2");
         map.put("source_name", "ebi");
-//        map.put("type", "class");
+        map.put("type", "class");
         map.put("source_url", null); //TODO: add source_url
         return map;
     }
@@ -176,7 +176,7 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
         result.put("obsolete", false);
         result.put("source", "https://semanticlookup.zbmed.de/ols/api");
         result.put("label", "Bacteria");
-//        result.put("type", null); //TODO: fix this
+        result.put("type", null); //TODO: fix this
         result.put("descriptions", Collections.emptyList());
         result.put("version", null);
         result.put("source_url", "https://semanticlookup.zbmed.de/ols/api/ontologies/ncbitaxon/terms/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FNCBITaxon_2?lang=en");
@@ -197,7 +197,7 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
         map.put("descriptions", List.of("A summary of the resource."));
         map.put("obsolete", false);
         map.put("source", "https://data.agroportal.lirmm.fr");
-//        map.put("type", "http://www.w3.org/2002/07/owl#AnnotationProperty");
+        map.put("type", "http://www.w3.org/2002/07/owl#AnnotationProperty");
         map.put("version", null); //TODO: to remove maybe
         map.put("source_url", null); //TODO: add source_url
         map.put("short_form", "abstract");
@@ -246,7 +246,7 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
         fixture.put("source_url", "http://agroportal.lirmm.fr/ontologies/AGROVOC?p=classes&conceptid=http%3A%2F%2Faims.fao.org%2Faos%2Fagrovoc%2Fc_330834");
         fixture.put("version", null);
         fixture.put("ontology_iri", null); //TODO: fix this
-//        fixture.put("type", "http://www.w3.org/2004/02/skos/core#Concept"); // TODO implement default value logic
+        fixture.put("type", "http://www.w3.org/2004/02/skos/core#Concept"); // TODO implement default value logic
         return fixture;
     }
 
@@ -261,7 +261,7 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
         fixture.put("ontology", "https://data.agroportal.lirmm.fr/ontologies/INRAETHES");
         fixture.put("descriptions", Collections.emptyList());
         fixture.put("synonyms", Collections.emptyList());
-//        fixture.put("type", "http://www.w3.org/2004/02/skos/core#Collection");
+        fixture.put("type", "http://www.w3.org/2004/02/skos/core#Collection");
         fixture.put("created", null);
         fixture.put("modified", null);
         fixture.put("obsolete", false);
@@ -276,7 +276,7 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
         fixture.put("backend_type", "ols");
         fixture.put("source_name", "zbmed");
         fixture.put("source", "https://semanticlookup.zbmed.de/ols/api");
-//        fixture.put("type", null); //TODO: fix this
+        fixture.put("type", null); //TODO: fix this
         fixture.put("descriptions", List.of("LanguaL curation note: US FDA 1995 Code:  QR"));
         fixture.put("source_url", "https://semanticlookup.zbmed.de/ols/api/ontologies/foodon/individuals/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FGAZ_00000464?lang=en");
         return fixture;
@@ -288,7 +288,7 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
         fixture.put("source", "https://www.ebi.ac.uk/ols4/api/v2");
         fixture.put("source_name", "ebi");
         fixture.put("ontology", "foodon");
-//        fixture.put("type", "individual");
+        fixture.put("type", "individual");
         fixture.put("descriptions", List.of("LanguaL curation note: US FDA 1995 Code:  QR"));
         fixture.put("ontology_iri", "http://purl.obolibrary.org/obo/foodon.owl");
         return fixture;
@@ -300,7 +300,7 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
         fixture.put("source", "https://data.agroportal.lirmm.fr");
         fixture.put("source_name", "agroportal");
         fixture.put("ontology", null); //TODO: fix this
-//        fixture.put("type", "http://www.w3.org/2002/07/owl#NamedIndividual"); //TODO: harmonize with ols types
+        fixture.put("type", "http://www.w3.org/2002/07/owl#NamedIndividual"); //TODO: harmonize with ols types
         return fixture;
     }
 
@@ -331,7 +331,7 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
         fixture.put("created", null);
         fixture.put("obsolete", false);
         fixture.put("source", "https://data.agroportal.lirmm.fr");
-//        fixture.put("type", "http://www.w3.org/2004/02/skos/core#ConceptScheme");
+        fixture.put("type", "http://www.w3.org/2004/02/skos/core#ConceptScheme");
         fixture.put("descriptions", Collections.emptyList());
         fixture.put("version", null);
         fixture.put("source_url", null);
@@ -351,7 +351,7 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
         fixture.put("obsolete", false);
         fixture.put("source", "https://lobid.org");
         fixture.put("label", "London");
-//        fixture.put("type", "AuthorityResource");
+        fixture.put("type", "AuthorityResource");
         fixture.put("descriptions", List.of("Hauptstadt des Vereinigten Königreichs von Großbritannien und Nordirland, in Mittelsteinzeit besiedelt, 43 n. Chr. von Römern gegründet; das County of London war 1889-1965 Verwaltungsgrafschaft u. zeremonielle Grafschaft"));
         fixture.put("version", null);
         fixture.put("source_url", "https://d-nb.info/gnd/4074335-4");

--- a/src/test/java/org/semantics/apigateway/ArtefactServiceTest.java
+++ b/src/test/java/org/semantics/apigateway/ArtefactServiceTest.java
@@ -3,6 +3,7 @@ package org.semantics.apigateway;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.semantics.apigateway.model.CommonRequestParams;
+import org.semantics.apigateway.model.SemanticArtefact;
 import org.semantics.apigateway.model.responses.AggregatedApiResponse;
 import org.semantics.apigateway.service.artefacts.ArtefactsService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +21,7 @@ public class ArtefactServiceTest extends ApplicationTestAbstract {
     @BeforeEach
     public void setup() {
         mockApiAccessor("artefact", artefactsService.getAccessor());
+        this.responseClass = SemanticArtefact.class;
     }
 
 

--- a/src/test/java/org/semantics/apigateway/ArtefactsServiceTest.java
+++ b/src/test/java/org/semantics/apigateway/ArtefactsServiceTest.java
@@ -3,6 +3,7 @@ package org.semantics.apigateway;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.semantics.apigateway.model.CommonRequestParams;
+import org.semantics.apigateway.model.SemanticArtefact;
 import org.semantics.apigateway.model.responses.AggregatedApiResponse;
 import org.semantics.apigateway.service.artefacts.ArtefactsService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,32 +28,32 @@ public class ArtefactsServiceTest extends ApplicationTestAbstract {
     @BeforeEach
     public void setup() {
         mockApiAccessor("artefacts", artefactsService.getAccessor());
+        this.responseClass = SemanticArtefact.class;
     }
 
     @Test
     public void testGetAllArtefacts() {
         AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefacts(new CommonRequestParams(), null, null, apiAccessor);
+        int index;
         List<Map<String, Object>> responseList = response.getCollection();
 
-        assertThat(responseList.size()).isEqualTo(724);
 
-        Map<String, Object> ontoportalItem = findByShortFormAndBackendType(responseList, "AGROVOC", "ontoportal");
-        assertThat(ontoportalItem).containsAllEntriesOf(createOntoportalAgrovocFixture());
+        index = indexOfShortFormAndBackendType(responseList, "AGROVOC", "ontoportal");
+        assertMapEquality(response, createOntoportalAgrovocFixture(), 724, index);
 
-        Map<String, Object> skosmosItem = findByShortFormAndBackendType(responseList, "agrovoc", "skosmos");
+        index = indexOfShortFormAndBackendType(responseList, "agrovoc", "skosmos");
         Map<String, Object> skosmosExpected = createSkosmosAgrovocFixture();
         skosmosExpected.put("iri", "agrovoc");
-        assertThat(skosmosItem).containsAllEntriesOf(skosmosExpected);
+        assertMapEquality(response, skosmosExpected, 724, index);
 
-        Map<String, Object> olsItem = findByShortFormAndBackendType(responseList, "bto", "ols");
-        assertThat(olsItem).containsAllEntriesOf(createOlsFixture());
+        index = indexOfShortFormAndBackendType(responseList, "bto", "ols");
+        assertMapEquality(response, createOlsFixture(), 724, index);
 
-        Map<String, Object> ols2Item = findByShortFormAndBackendType(responseList, "bto", "ols2");
-        assertThat(ols2Item).containsAllEntriesOf(createOls2Fixture());
+        index = indexOfShortFormAndBackendType(responseList, "bto", "ols2");
+        assertMapEquality(response, createOls2Fixture(), 724, index);
 
-        Map<String, Object> gndItem = findByShortFormAndBackendType(responseList, "GND", "gnd");
-
-        assertThat(gndItem).containsAllEntriesOf(createGndFixture());
+        index = indexOfShortFormAndBackendType(responseList, "GND", "gnd");
+        assertMapEquality(response, createGndFixture(), 724, index);
 
         assertThat(responseList.stream().map(x -> x.get("source_name")).distinct().sorted().toArray())
                 .isEqualTo(new String[]{"agroportal", "agrovoc", "ebi", "gnd", "tib"});
@@ -67,13 +68,11 @@ public class ArtefactsServiceTest extends ApplicationTestAbstract {
         fixture.put("short_form", "bto");
         fixture.put("label", "The BRENDA Tissue Ontology (BTO)");
         fixture.put("source_name", "tib");
-        fixture.put("ontology", "bto");
         fixture.put("synonyms", Collections.emptyList());
         fixture.put("created", null);
         fixture.put("obsolete", false);
         fixture.put("source_url", "https://service.tib.eu:443/ts4tib/api/ontologies/bto");
         fixture.put("modified", null);
-        fixture.put("ontology_iri", null);
         fixture.put("version", "2021-10-26");
         fixture.put("descriptions", List.of(
                 "A structured controlled vocabulary for the source of an enzyme comprising tissues, cell lines, cell types and cell cultures."
@@ -90,13 +89,11 @@ public class ArtefactsServiceTest extends ApplicationTestAbstract {
         fixture.put("source", "https://www.ebi.ac.uk/ols4/api/v2");
         fixture.put("type", "ontology");
         fixture.put("source_name", "ebi");
-        fixture.put("ontology", "bto");
         fixture.put("synonyms", Collections.emptyList());
         fixture.put("created", null);
         fixture.put("obsolete", false);
         fixture.put("source_url", null);
         fixture.put("modified", "2025-03-16T21:34:29.847078927");
-        fixture.put("ontology_iri", "http://purl.obolibrary.org/obo/bto.owl");
         fixture.put("version", null);
         fixture.put("descriptions", List.of(
                 "A structured controlled vocabulary for the source of an enzyme comprising tissues, cell lines, cell types and cell cultures."

--- a/src/test/java/org/semantics/apigateway/CommonRequestParamsTest.java
+++ b/src/test/java/org/semantics/apigateway/CommonRequestParamsTest.java
@@ -1,0 +1,65 @@
+package org.semantics.apigateway;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.semantics.apigateway.model.CommonRequestParams;
+import org.semantics.apigateway.model.SemanticArtefact;
+import org.semantics.apigateway.model.responses.AggregatedApiResponse;
+import org.semantics.apigateway.model.responses.AggregatedResourceBody;
+import org.semantics.apigateway.service.artefacts.ArtefactsService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class CommonRequestParamsTest extends ApplicationTestAbstract {
+
+    @Autowired
+    private ArtefactsService artefactsService;
+
+
+    @BeforeEach
+    public void setup() {
+        mockApiAccessor("artefacts", artefactsService.getAccessor());
+        this.responseClass = SemanticArtefact.class;
+    }
+
+    @Test
+    public void testGetAllArtefactsWithDisplay() {
+        CommonRequestParams params = new CommonRequestParams();
+        params.setDisplay("short_form,backend_type,descriptions,synonyms,label");
+        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefacts(params, null, null, apiAccessor);
+        int index;
+        List<Map<String, Object>> responseList = response.getCollection();
+
+        index = indexOfShortFormAndBackendType(responseList, "AGROVOC", "ontoportal");
+        Map<String, Object> object = responseList.get(index);
+        Map<String, Object> expected = createOntoportalAgrovocFixture();
+        assertThat(object.get("synonyms")).isEqualTo(expected.get("synonyms"));
+        assertThat(object.get("label")).isEqualTo(expected.get("label"));
+        assertThat(object.get("descriptions")).isEqualTo(expected.get("descriptions"));
+        assertThat(object.keySet().stream().sorted().toList())
+                .isEqualTo(Stream.of("descriptions", "synonyms", "label", "@type", "@context", "short_form", "backend_type").sorted().toList());
+    }
+
+
+    @Test
+    public void testGetAllArtefactsWithNotDisplayEmptyValues() {
+        CommonRequestParams params = new CommonRequestParams();
+        params.setDisplayEmptyValues(false);
+        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefacts(params, null, null, apiAccessor);
+        int index;
+        List<Map<String, Object>> responseList = response.getCollection();
+
+        index = indexOfShortFormAndBackendType(responseList, "AGROVOC", "ontoportal");
+        Map<String, Object> object = responseList.get(index);
+        object.forEach((key, value) -> assertThat(AggregatedResourceBody.isEmpty(value)).isFalse());
+    }
+}

--- a/src/test/java/org/semantics/apigateway/SearchServiceTest.java
+++ b/src/test/java/org/semantics/apigateway/SearchServiceTest.java
@@ -87,11 +87,11 @@ public class SearchServiceTest extends ApplicationTestAbstract {
         Map<String, Object> firstPlant = new HashMap<>();
         firstPlant.put("iri", "http://sweetontology.net/matrPlant/Plant");
         firstPlant.put("backend_type", "ontoportal");
-//        firstPlant.put("short_form", null); // TODO implement default value logic
+        firstPlant.put("short_form", "Plant");
         firstPlant.put("label", "plant");
         firstPlant.put("source", "https://data.biodivportal.gfbio.org");
-//        firstPlant.put("type", null); // TODO implement default value logic
-//        firstPlant.put("ontology", null); // TODO implement default value logic
+        firstPlant.put("type", "http://www.w3.org/2002/07/owl#Class");
+        firstPlant.put("ontology", "https://data.biodivportal.gfbio.dev/ontologies/SWEET");
         return firstPlant;
     }
 
@@ -118,8 +118,6 @@ public class SearchServiceTest extends ApplicationTestAbstract {
         thirdPlant.put("source", "https://www.ebi.ac.uk/ols4/api/v2");
         thirdPlant.put("@type", new RDFResource().getTypeURI()); //TODO: should be owl:Class in future
         thirdPlant.put("ontology", "biolink");
-//        assertThat(secondPlant.get("descriptions")) // TODO: check if this is correct
-//                .isEqualTo(new ArrayList<String>(List.of(new String[]{"Any living organism that typically synthesizes its food from inorganic substances, possesses cellulose cell walls, responds slowly and often permanently to a stimulus, lacks specialized sense organs and nervous system, and has no powers of locomotion. (EPA Terminology Reference System)"})));
         return thirdPlant;
     }
 
@@ -130,7 +128,7 @@ public class SearchServiceTest extends ApplicationTestAbstract {
         gndPlant.put("synonyms", List.of("Londen", "Corporation of London", "Augusta Trinobantum", "Landan", "Londres", "Londinum", "County of London", "Lundonia", "Londra", "Londyn", "Greater London", "London (Great Britain)", "Londinium", "Westminster", "Lundun"));
         gndPlant.put("source", "https://lobid.org");
         gndPlant.put("label", "London");
-//        gndPlant.put("type", "AuthorityResource");
+        gndPlant.put("type", "AuthorityResource");
         gndPlant.put("descriptions", List.of("Hauptstadt des Vereinigten Königreichs von Großbritannien und Nordirland, in Mittelsteinzeit besiedelt, 43 n. Chr. von Römern gegründet; das County of London war 1889-1965 Verwaltungsgrafschaft u. zeremonielle Grafschaft"));
         gndPlant.put("source_url", "https://d-nb.info/gnd/4074335-4");
         gndPlant.put("short_form", "4074335-4");

--- a/src/test/java/org/semantics/apigateway/SearchServiceTest.java
+++ b/src/test/java/org/semantics/apigateway/SearchServiceTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.semantics.apigateway.model.CommonRequestParams;
+import org.semantics.apigateway.model.RDFResource;
 import org.semantics.apigateway.model.ResponseFormat;
 import org.semantics.apigateway.model.TargetDbSchema;
 import org.semantics.apigateway.model.responses.AggregatedApiResponse;
@@ -32,28 +33,29 @@ public class SearchServiceTest extends ApplicationTestAbstract {
     @BeforeEach
     public void setup() {
         mockApiAccessor("search", searchService.getAccessor());
+        this.responseClass = RDFResource.class;
     }
 
     @Test
     public void testSearchAllDatabases() {
         CommonRequestParams commonRequestParams = new CommonRequestParams();
         AggregatedApiResponse response = (AggregatedApiResponse) searchService.performSearch("plant", commonRequestParams, null, null, null, apiAccessor);
-
+        int index;
         List<Map<String, Object>> responseList = response.getCollection();
 
-        assertThat(responseList).hasSize(100);
-
-        assertThat(responseList.stream().allMatch(x -> x.containsKey("label") && x.get("label").toString().toLowerCase().startsWith("plant"))).isTrue();
-
         //TODO need a better testing of the ranking
-        Map<String, Object> firstPlant = findByIriAndBackendType(responseList, "http://sweetontology.net/matrPlant/Plant", "ontoportal");
-        assertThat(firstPlant).containsAllEntriesOf(createOntoPortalPlantFixture());
+        assertThat(responseList.stream()
+                .allMatch(x -> x.containsKey("label") && x.get("label").toString().toLowerCase().startsWith("plant")))
+                .isTrue();
 
-        Map<String, Object> secondPlant = findByIriAndBackendType(responseList, "http://purl.obolibrary.org/obo/NCIT_C14258", "ols");
-        assertThat(secondPlant).containsAllEntriesOf(createOlsPlantFixture());
+        index = indexOfIriAndBackendType(responseList, "http://sweetontology.net/matrPlant/Plant", "ontoportal");
+        assertMapEquality(response, createOntoPortalPlantFixture(), 100, index);
 
-        secondPlant = findByIriAndBackendType(responseList, "https://w3id.org/biolink/vocab/Plant", "ols2");
-        assertThat(secondPlant).containsAllEntriesOf(createOls2Fixture());
+        index = indexOfIriAndBackendType(responseList, "http://purl.obolibrary.org/obo/NCIT_C14258", "ols");
+        assertMapEquality(response, createOlsPlantFixture(), 100, index);
+
+        index = indexOfIriAndBackendType(responseList, "https://w3id.org/biolink/vocab/Plant", "ols2");
+        assertMapEquality(response, createOls2Fixture(), 100, index);
 
         assertThat(responseList.stream().map(x -> x.get("backend_type")).distinct().sorted().toArray())
                 .isEqualTo(new String[]{"ols", "ols2", "ontoportal", "skosmos"});
@@ -73,7 +75,6 @@ public class SearchServiceTest extends ApplicationTestAbstract {
         List<Map<String, Object>> responseList = (List<Map<String, Object>>) ((Map<String, Object>) response.get("response")).get("docs");
 
         assertThat(responseList).hasSize(100);
-
     }
 
     @Test
@@ -94,10 +95,7 @@ public class SearchServiceTest extends ApplicationTestAbstract {
         CommonRequestParams commonRequestParams = new CommonRequestParams();
         commonRequestParams.setDatabase("gnd");
         AggregatedApiResponse response = (AggregatedApiResponse) searchService.performSearch("London", commonRequestParams, null, null, null, apiAccessor);
-        List<Map<String, Object>> responseList = response.getCollection();
-        assertThat(responseList).hasSize(10);
-        Map<String, Object> firstPlant = responseList.get(0);
-        assertThat(firstPlant).containsAllEntriesOf(createGndLondonFixture());
+        assertMapEquality(response, createGndLondonFixture(), 10);
     }
 
     private Map<String, Object> createOntoPortalPlantFixture() {
@@ -119,7 +117,8 @@ public class SearchServiceTest extends ApplicationTestAbstract {
         secondPlant.put("short_form", "NCIT_C14258");
         secondPlant.put("label", "Plant");
         secondPlant.put("source", "https://service.tib.eu/ts4tib/api");
-        secondPlant.put("type", "class");
+        secondPlant.put("@type", new RDFResource().getTypeURI()); //TODO: should be owl:Class in future
+        secondPlant.put("@id", secondPlant.get("iri"));
         secondPlant.put("ontology", "ncit");
         secondPlant.put("descriptions", List.of("Any living organism that typically synthesizes its food from inorganic substances, possesses cellulose cell walls, responds slowly and often permanently to a stimulus, lacks specialized sense organs and nervous system, and has no powers of locomotion. (EPA Terminology Reference System)"));
         return secondPlant;
@@ -132,9 +131,9 @@ public class SearchServiceTest extends ApplicationTestAbstract {
         thirdPlant.put("short_form", "Plant");
         thirdPlant.put("label", "plant");
         thirdPlant.put("source", "https://www.ebi.ac.uk/ols4/api/v2");
-        thirdPlant.put("type", "class");
+        thirdPlant.put("@type", new RDFResource().getTypeURI()); //TODO: should be owl:Class in future
         thirdPlant.put("ontology", "biolink");
-//        assertThat(secondPlant.get("descriptions"))
+//        assertThat(secondPlant.get("descriptions")) // TODO: check if this is correct
 //                .isEqualTo(new ArrayList<String>(List.of(new String[]{"Any living organism that typically synthesizes its food from inorganic substances, possesses cellulose cell walls, responds slowly and often permanently to a stimulus, lacks specialized sense organs and nervous system, and has no powers of locomotion. (EPA Terminology Reference System)"})));
         return thirdPlant;
     }
@@ -146,7 +145,7 @@ public class SearchServiceTest extends ApplicationTestAbstract {
         gndPlant.put("synonyms", List.of("Londen", "Corporation of London", "Augusta Trinobantum", "Landan", "Londres", "Londinum", "County of London", "Lundonia", "Londra", "Londyn", "Greater London", "London (Great Britain)", "Londinium", "Westminster", "Lundun"));
         gndPlant.put("source", "https://lobid.org");
         gndPlant.put("label", "London");
-        gndPlant.put("type", "AuthorityResource");
+//        gndPlant.put("type", "AuthorityResource");
         gndPlant.put("descriptions", List.of("Hauptstadt des Vereinigten Königreichs von Großbritannien und Nordirland, in Mittelsteinzeit besiedelt, 43 n. Chr. von Römern gegründet; das County of London war 1889-1965 Verwaltungsgrafschaft u. zeremonielle Grafschaft"));
         gndPlant.put("source_url", "https://d-nb.info/gnd/4074335-4");
         gndPlant.put("short_form", "4074335-4");

--- a/src/test/java/org/semantics/apigateway/SearchServiceTest.java
+++ b/src/test/java/org/semantics/apigateway/SearchServiceTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.semantics.apigateway.model.CommonRequestParams;
 import org.semantics.apigateway.model.RDFResource;
-import org.semantics.apigateway.model.ResponseFormat;
 import org.semantics.apigateway.model.TargetDbSchema;
 import org.semantics.apigateway.model.responses.AggregatedApiResponse;
 import org.semantics.apigateway.service.search.SearchService;
@@ -17,7 +16,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -76,19 +74,6 @@ public class SearchServiceTest extends ApplicationTestAbstract {
 
         assertThat(responseList).hasSize(100);
     }
-
-    @Test
-    public void testSearchJsonLdFormat() throws ExecutionException, InterruptedException {
-        CommonRequestParams commonRequestParams = new CommonRequestParams();
-        commonRequestParams.setFormat(ResponseFormat.jsonld);
-        AggregatedApiResponse response = (AggregatedApiResponse) searchService.performSearch("plant", commonRequestParams, null, null, null, apiAccessor);
-
-        Map<String, Object> firstPlant = response.getCollection().get(0);
-        assertThat(firstPlant.containsKey("@type")).isTrue();
-        assertThat(firstPlant.containsKey("@context")).isTrue();
-        //TODO add more assertions to check to @context content
-    }
-
 
     @Test
     public void testSearchGnd(){


### PR DESCRIPTION
### Context
This PR introduce two major changes:
1. We return only `json ld `, the parameter `format=json` was removed 
2. Added two new parameters `display` to fishow only a subset of attributes (e.g d`isplay=label,descriptions` will show only both attribute for each of the returned results) and `displayEmptyValues` by default enabled, if disabled if will hide and show only attributes with no empty values (not null or []) 
![image](https://github.com/user-attachments/assets/e4410e29-aa06-4059-a645-1b1ed2cd6ec6)

### Changes
* Add json ld tests by default for all the unit tests (https://github.com/ts4nfdi/api-gateway/commit/5194ed559fef7db204eb8a51bea651d8360c242e)
* Show jsonld format only and remove json format (https://github.com/ts4nfdi/api-gateway/commit/0c452dd819972a00584da9822ee36b9a0d7c8c6d)
* Implement the "display" parameter, to give the option what attributes to show (https://github.com/ts4nfdi/api-gateway/commit/e654c426b879daf243ecdafc5ec46e0c9491b882)
* Add context URI annotations & usage to declare the context of each attr (https://github.com/ts4nfdi/api-gateway/commit/3f5717fea1aa503e68ae036daea64ef637240e92)
* Implement context generation for JSON LD transformer (https://github.com/ts4nfdi/api-gateway/commit/0f2b4a680aefbb81898effbe53894396dd28a6c5)
Add the code, to transform
![image](https://github.com/user-attachments/assets/9fab7b65-c479-44a7-b744-2bde85d170cb)

Automatically to 
![image](https://github.com/user-attachments/assets/5ea952cd-14e1-48aa-a754-ba3e4d4d38d1)

* Add tests for JSON LD transformer (https://github.com/ts4nfdi/api-gateway/commit/407ae219ce696e5dea47070c279218128da6e4ef)
* add tests for the new common request params "display" and "displayNoEmptyValues (https://github.com/ts4nfdi/api-gateway/pull/77/commits/cc960bc518be388911f3a06fa1332f2a1e90d058)
[cc960bc](https://github.com/ts4nfdi/api-gateway/pull/77/commits/cc960bc518be388911f3a06fa1332f2a1e90d058)
