### PR TITLE
ci: deploy dev branch to qa cluster

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -3,7 +3,7 @@ name: CI/CD
 on:
   push:
     branches:
-      - "main"
+      - "dev"
     tags:
       - "*"
 
@@ -107,7 +107,7 @@ jobs:
             kubectl get nodes
             helmv3 repo add api-gateway-deployment https://ts4nfdi.github.io/api-gateway-deployment/
             helmv3 repo update
-            helmv3 upgrade ts4nfdi \
+            helmv3 upgrade ts4nfdi-api-gateway \
               --install \
               --namespace='ts4nfdi' \
               --set-json='ingress.dns="tsag.qa.km.k8s.zbmed.de"'  \

--- a/.github/workflows/prod-deployment.yml
+++ b/.github/workflows/prod-deployment.yml
@@ -60,7 +60,7 @@ jobs:
             kubectl get nodes
             helmv3 repo add api-gateway-deployment https://ts4nfdi.github.io/api-gateway-deployment/
             helmv3 repo update
-            helmv3 upgrade ts4nfdi \
+            helmv3 upgrade ts4nfdi-api-gateway \
               --install \
               --namespace='ts4nfdi' \
               --set-json='ingress.dns="terminology.services.base4nfdi.de"'  \


### PR DESCRIPTION
Instead having the same branch deployed on qa and prod clusters, we deploy dev branch to qa and main branch to prod.