### PR TITLE
Add additional potential id properties to jskos2. Resolves #145

### DIFF
--- a/src/main/resources/backend_types/jskos2.yml
+++ b/src/main/resources/backend_types/jskos2.yml
@@ -6,7 +6,7 @@ pagination:
 
 models:
   artefact: &artefact
-    iri: uri
+    iri: uri|url|namespace
     type: type
     label: prefLabel->en|prefLabel->de|prefLabel->zxx
     descriptions: definition->en|definition->de|definition->zxx|scopeNote->en|scopeNote->de|scopeNote->zxx


### PR DESCRIPTION
This PR solves the issue that the frontend displays no link for the ICONCLASS semantic artefact.
The reason was that, according to the jskos2 specification, the `uri` property, which the current jskos2 mapping relied on, is only optional and (rightfully) not set by the ICONCLASS backend.
This PR extends the jskos2 mapping by additionally allowing the (also optional) properties `url` and `namespace` to act as the primary vocabulary identifier and maps them to the gateway's internal `iri` property as well.
The result is that now the first present and non-empty property from this list (in this order) will be used: `uri`, `url`, `namespace`.