### PR TITLE
Fix/ontoportal response format

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,9 @@ dependencies {
     implementation 'org.apache.lucene:lucene-analyzers-common:8.11.2'
     implementation 'org.apache.lucene:lucene-queryparser:9.11.1'
 
+    // cosine similarity for search result
+    implementation 'org.apache.commons:commons-text:1.12.0'
+
     // Jena for RDF manipulation
     implementation 'org.apache.jena:jena-iri:3.16.0'
     implementation 'org.apache.jena:jena-core:3.16.0'

--- a/src/main/java/org/semantics/apigateway/api/OntoPortalTransformer.java
+++ b/src/main/java/org/semantics/apigateway/api/OntoPortalTransformer.java
@@ -1,83 +1,177 @@
 package org.semantics.apigateway.api;
 
 import org.semantics.apigateway.config.ResponseMapping;
+import org.semantics.apigateway.model.responses.AggregatedResourceBody;
+import org.semantics.apigateway.service.JsonLdTransform;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
 
 public class OntoPortalTransformer implements DatabaseTransformer {
+
+    private final Map<String, Object> contextConfig;
+    private final JsonLdTransform jsonLdTransform;
+
+    public OntoPortalTransformer(Map<String, Object> contextConfig, JsonLdTransform jsonLdTransform) {
+        this.contextConfig = contextConfig;
+        this.jsonLdTransform = jsonLdTransform;
+    }
+
     @Override
     public Map<String, Object> transformItem(Map<String, Object> item, ResponseMapping mapping) {
         if (item == null) {
             return null;
         }
 
-        Map<String, Object> transformedItem = new HashMap<>();
+        Map<String, Object> transformedItem = new LinkedHashMap<>();
 
-        // Check for null values before accessing properties
-        if (item.containsKey("@id") && item.get("@id") != null) {
-            transformedItem.put("iri", item.get("@id"));
+        String iri = getStringValue(item, "iri");
+        String label = getStringValue(item, "label");
+        String type = getStringValue(item, "type");
+        String ontology = getStringValue(item, "ontology");
+        String source = getStringValue(item, "source");
+        String sourceUrl = getStringValue(item, "source_url");
+
+        // Core fields
+        if (label != null) {
+            transformedItem.put("prefLabel", label);
         }
-        if (item.containsKey("label") && item.get("label") != null) {
-            transformedItem.put("prefLabel", item.get("label"));
+
+        Object synonyms = item.get("synonyms");
+        if (synonyms != null && !(synonyms instanceof List && ((List<?>) synonyms).isEmpty())) {
+            transformedItem.put("synonym", synonyms);
         }
-        if (item.containsKey("ontology") && item.get("ontology") != null) {
-            transformedItem.put("@type", item.get("ontology"));
+
+        Object definitions = item.get("descriptions");
+        if (definitions != null && !(definitions instanceof List && ((List<?>) definitions).isEmpty())) {
+            transformedItem.put("definition", definitions);
         }
-        if (item.containsKey("synonym") && item.get("synonym") != null) {
-            transformedItem.put("synonym", item.get("synonym"));
+
+        transformedItem.put("obsolete", item.getOrDefault("obsolete", false));
+
+        String matchType = getStringValue(item, "match_type");
+        if (matchType != null) {
+            transformedItem.put("matchType", matchType);
         }
-        if (item.containsKey("backend_type") && item.get("backend_type") != null) {
-            transformedItem.put("backend_type", item.get("backend_type"));
+
+        String ontologyType = getStringValue(item, "ontology_type");
+        if (ontologyType != null) {
+            transformedItem.put("ontologyType", ontologyType);
         }
-        if (item.containsKey("short_form") && item.get("short_form") != null) {
-            transformedItem.put("short_form", item.get("short_form"));
+
+        String sourceName = getStringValue(item, "source_name");
+        if(sourceName != null){
+            transformedItem.put("source", sourceName);
         }
-        if (item.containsKey("description") && item.get("description") != null) {
-            transformedItem.put("definition", item.get("description"));
+
+            if (iri != null) {
+            transformedItem.put("@id", iri);
         }
-        if (item.containsKey("source") && item.get("source") != null) {
-            transformedItem.put("source", item.get("source"));
+
+        if (type != null) {
+            transformedItem.put("@type", type);
         }
-        if (item.containsKey("type") && item.get("type") != null) {
-            // the value of the key @type in OntoPortal is saved as an IRI
-            if (item.containsKey("backend_type") && String.valueOf(item.get("backend_type")).equals("ols")) {
-                if (item.get("type").equals("class")) {
-                    transformedItem.put("type", "http://www.w3.org/2002/07/owl#Class");
-                } else {
-                    transformedItem.put("type", item.get("type"));
-                }
-            } else {
-                transformedItem.put("type", item.get("type"));
+
+        // Build links
+        if (source != null && ontology != null && iri != null) {
+            String encodedIri = URLEncoder.encode(iri, StandardCharsets.UTF_8);
+            String ontologyAcronym = ontology.contains("/") ? ontology.substring(ontology.lastIndexOf('/') + 1) : ontology;
+            String selfUrl = source + "/ontologies/" + ontologyAcronym + "/classes/" + encodedIri;
+            String ontologyUrl = source + "/ontologies/" + ontologyAcronym;
+
+            Map<String, Object> links = new LinkedHashMap<>();
+            links.put("self", selfUrl);
+            links.put("ontology", ontologyUrl);
+            links.put("children", selfUrl + "/children");
+            links.put("parents", selfUrl + "/parents");
+            links.put("descendants", selfUrl + "/descendants");
+            links.put("ancestors", selfUrl + "/ancestors");
+            links.put("instances", selfUrl + "/instances");
+            links.put("tree", selfUrl + "/tree");
+            links.put("notes", selfUrl + "/notes");
+            links.put("mappings", selfUrl + "/mappings");
+
+            if (sourceUrl != null) {
+                links.put("ui", sourceUrl);
             }
+
+            // Links @context from YAML config
+            Map<String, Object> linksContext = buildLinksContext();
+            links.put("@context", linksContext);
+
+            transformedItem.put("links", links);
         }
-        if (item.containsKey("annotations") && item.get("annotations") != null && item.get("annotations") instanceof Map) {
-            Map<String, List<String>> annotations = (Map<String, List<String>>) item.get("annotations");
-            annotations.forEach((annotationProperty, annotationValues) -> {
-                if (annotationValues != null && !annotationValues.isEmpty()) {
-                    transformedItem.put(annotationProperty, annotationValues);
-                }
-            });
-        }
+
+        // Item-level @context generated from annotations
+        Map<String, Object> context = buildItemContext();
+        transformedItem.put("@context", context);
+
         return transformedItem;
     }
 
     @Override
     public Map<String, Object> constructResponse(List<Map<String, Object>> transformedResults, String mappingKey, boolean list, boolean paginate, int page, long totalCount) {
-        Map<String, Object> response = new HashMap<>();
-        response.put("page", page);
-        response.put("pageCount", 1); // TODO
-        response.put("totalCount", transformedResults.size());
-        response.put("prevPage", null);
-        response.put("nextPage", null);
-        Map<String, Object> links = new HashMap<>();
-        links.put("nextPage", null);
-        links.put("prevPage", null);
-        response.put("links", links);
+        Map<String, Object> response = new LinkedHashMap<>();
+
+        response.put("totalCount", totalCount > 0 ? totalCount : transformedResults.size());
         response.put("collection", transformedResults);
-        response.put("@context", Collections.singletonMap("@vocab", ""));
+
         return response;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> buildItemContext() {
+        Map<String, Object> context = new LinkedHashMap<>();
+
+        String vocab = contextConfig != null ? (String) contextConfig.get("vocab") : null;
+        String language = contextConfig != null ? (String) contextConfig.get("language") : null;
+        Map<String, String> fieldMappings = contextConfig != null ? (Map<String, String>) contextConfig.get("fieldMappings") : null;
+        Map<String, String> fieldOverrides = contextConfig != null ? (Map<String, String>) contextConfig.get("fieldOverrides") : null;
+
+        if (vocab != null) {
+            context.put("@vocab", vocab);
+        }
+
+        // Generate context from @ContextUri annotations
+        if (fieldMappings != null && jsonLdTransform != null) {
+            Map<String, String> generatedContext = jsonLdTransform.generateContext(
+                    org.semantics.apigateway.model.RDFResource.class, null);
+
+            for (Map.Entry<String, String> entry : fieldMappings.entrySet()) {
+                String ontoPortalKey = entry.getKey();    // e.g. "prefLabel"
+                String javaFieldName = entry.getValue();   // e.g. "label"
+
+                // Check for override first
+                if (fieldOverrides != null && fieldOverrides.containsKey(ontoPortalKey)) {
+                    context.put(ontoPortalKey, fieldOverrides.get(ontoPortalKey));
+                } else if (generatedContext.containsKey(javaFieldName)) {
+                    context.put(ontoPortalKey, generatedContext.get(javaFieldName));
+                }
+            }
+        }
+
+        if (language != null) {
+            context.put("@language", language);
+        }
+
+        return context;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> buildLinksContext() {
+        if (contextConfig == null) {
+            return new LinkedHashMap<>();
+        }
+        Map<String, String> linksConfig = (Map<String, String>) contextConfig.get("links");
+        if (linksConfig == null) {
+            return new LinkedHashMap<>();
+        }
+        return new LinkedHashMap<>(linksConfig);
+    }
+
+    private String getStringValue(Map<String, Object> item, String key) {
+        Object value = item.get(key);
+        return value != null ? value.toString() : null;
     }
 }

--- a/src/main/java/org/semantics/apigateway/artefacts/search/SearchLocalIndexerService.java
+++ b/src/main/java/org/semantics/apigateway/artefacts/search/SearchLocalIndexerService.java
@@ -17,6 +17,8 @@ import org.apache.lucene.store.Directory;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Service;
 
+import org.apache.commons.text.similarity.CosineSimilarity;
+
 import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -26,6 +28,35 @@ import java.util.stream.Collectors;
 public class SearchLocalIndexerService {
 
     public static final String INDEXED_FIELD = "label";
+
+    public List<Map<String, Object>> sortByCosineSimilarity(String query, List<Map<String, Object>> results) {
+        CosineSimilarity cosineSimilarity = new CosineSimilarity();
+        Map<CharSequence, Integer> queryVector = toCharacterVector(query.toLowerCase());
+
+        return results.stream()
+                .sorted((a, b) -> {
+                    String labelA = a.get("label") != null ? a.get("label").toString().toLowerCase() : "";
+                    String labelB = b.get("label") != null ? b.get("label").toString().toLowerCase() : "";
+
+                    Map<CharSequence, Integer> vectorA = toCharacterVector(labelA);
+                    Map<CharSequence, Integer> vectorB = toCharacterVector(labelB);
+
+                    double scoreA = cosineSimilarity.cosineSimilarity(queryVector, vectorA);
+                    double scoreB = cosineSimilarity.cosineSimilarity(queryVector, vectorB);
+
+                    return Double.compare(scoreB, scoreA);
+                })
+                .collect(Collectors.toList());
+    }
+
+    private Map<CharSequence, Integer> toCharacterVector(String text) {
+        Map<CharSequence, Integer> vector = new HashMap<>();
+        for (char c : text.toCharArray()) {
+            String key = String.valueOf(c);
+            vector.put(key, vector.getOrDefault(key, 0) + 1);
+        }
+        return vector;
+    }
 
 
     public List<Map<String, Object>> reIndexResults(String query, List<Map<String, Object>> combinedResults, Logger logger) throws IOException, ParseException {
@@ -48,7 +79,7 @@ public class SearchLocalIndexerService {
         Query q = queryBuilder(field, terms, mainQuery);
 
 
-        TopDocs resultsTopDocs = searcher.search(q, 100);
+        TopDocs resultsTopDocs = searcher.search(q, Math.max(reader.numDocs(), 1));
 
 
         List<Map<String, Object>> newResults = new ArrayList<>();

--- a/src/main/java/org/semantics/apigateway/artefacts/search/SearchService.java
+++ b/src/main/java/org/semantics/apigateway/artefacts/search/SearchService.java
@@ -65,7 +65,7 @@ public class SearchService extends AbstractEndpointService {
                     .thenApply(data -> this.transformApiResponses(data, endpoint))
                     .thenApply(transformedData -> flattenResponseList(transformedData, params, collection))
                     .thenApply(data -> filterOutByCollection(collection, data))
-                    .thenApply(data -> reIndexResults(query, data))
+                    .thenApply(data -> sortResults(query, data))
                     .thenApply(x -> transformJsonLd(x, params))
                     .thenApply(data -> transformForTargetDbSchema(data, targetDbSchema, endpoint))
                     .get();
@@ -74,7 +74,7 @@ public class SearchService extends AbstractEndpointService {
             return null;
         }
     }
-    
+
     public AggregatedApiResponse suggestConcepts(
             String id,
             String query,
@@ -83,7 +83,7 @@ public class SearchService extends AbstractEndpointService {
             CommonRequestParams params) {
         return suggestConcepts(id, query, offset, size, params, null, null, null);
     }
-    
+
     public AggregatedApiResponse suggestConcepts(
             String id,
             String query,
@@ -99,15 +99,15 @@ public class SearchService extends AbstractEndpointService {
         TerminologyCollection collection = collectionService.getCurrentUserCollection(collectionId, currentUser);
         accessor = initAccessor(database, endpoint, accessor);
         accessor = applyCollection(accessor, collection, endpoint);
-        
+
         // TODO add ontology parameter as soon as https://github.com/ts4nfdi/api-gateway/issues/123 has been resolved.
-        
+
         try {
             return accessor.get(query, "" + size, "" + offset)
                     .thenApply(data -> this.transformApiResponses(data, endpoint))
                     .thenApply(transformedData -> flattenResponseList(transformedData, params, collection))
                     .thenApply(data -> filterOutByCollection(collection, data))
-                    .thenApply(data -> reIndexResults(query, data))
+                    .thenApply(data -> sortResults(query, data))
                     .thenApply(x -> transformJsonLd(x, params))
                     .thenApply(data -> transformForTargetDbSchema(data, targetDbSchema, endpoint))
                     .get();
@@ -117,6 +117,13 @@ public class SearchService extends AbstractEndpointService {
         }
     }
     
+    private AggregatedApiResponse sortResults(String query, AggregatedApiResponse data) {
+        List<Map<String, Object>> collection = data.getCollection();
+        collection = this.localIndexer.sortByCosineSimilarity(query.replace("*", ""), collection);
+        data.setCollection(collection);
+        return data;
+    }
+
     private AggregatedApiResponse reIndexResults(String query, AggregatedApiResponse data) {
         List<Map<String, Object>> collection = data.getCollection();
         try {

--- a/src/main/java/org/semantics/apigateway/config/ServiceConfig.java
+++ b/src/main/java/org/semantics/apigateway/config/ServiceConfig.java
@@ -19,6 +19,7 @@ public class ServiceConfig {
     private Pagination pagination;
     private Map<String, Object> models;
     private Map<String, EndpointConfig> endpoints;
+    private Map<String, Object> context;
 
     public DatabaseConfig getDatabaseConfig() {
         return new DatabaseConfig(name, "", "", "", this);

--- a/src/main/java/org/semantics/apigateway/model/RDFResource.java
+++ b/src/main/java/org/semantics/apigateway/model/RDFResource.java
@@ -20,7 +20,13 @@ public class RDFResource extends AggregatedResourceBody {
 
     @JsonProperty("ontology_iri")
     private String ontologyIri;
-    
+
+    @JsonProperty("match_type")
+    private String matchType;
+
+    @JsonProperty("ontology_type")
+    private String ontologyType;
+
     private boolean hasChildren = false;
 
     private List<RDFResource> children = new ArrayList<>();

--- a/src/main/java/org/semantics/apigateway/service/AbstractEndpointService.java
+++ b/src/main/java/org/semantics/apigateway/service/AbstractEndpointService.java
@@ -207,22 +207,12 @@ public abstract class AbstractEndpointService {
         List<Map<String, Object>> aggregatedCollections = data.stream()
                 .map(x -> x.getCollection(showResponseConfiguration, displayEmptyValues))
                 .flatMap(List::stream)
-                .sorted((m1, m2) -> {
-                    String label1 = (String) m1.getOrDefault("label", "");
-                    String label2 = (String) m2.getOrDefault("label", "");
-                    if (label1 == null) {
-                        label1 = "";
-                    }
-
-                    if (label2 == null) {
-                        label2 = "";
-                    }
-
-                    return label1.compareTo(label2);
-                })
                 .toList();
 
         aggregatedApiResponse.setCollection(aggregatedCollections);
+
+        long totalCount = aggregatedCollections.size();
+        aggregatedApiResponse.setTotalCount(totalCount);
 
         aggregatedApiResponse.setOriginalResponses(
                 data.stream().map(TransformedApiResponse::getOriginalResponse)

--- a/src/main/java/org/semantics/apigateway/service/ResponseTransformerService.java
+++ b/src/main/java/org/semantics/apigateway/service/ResponseTransformerService.java
@@ -16,11 +16,13 @@ import java.util.stream.Collectors;
 @Service
 @Getter
 public class ResponseTransformerService {
-  
+
   private final ConfigurationLoader configurationLoader;
-  
-  public ResponseTransformerService(ConfigurationLoader configurationLoader) {
+  private final JsonLdTransform jsonLdTransform;
+
+  public ResponseTransformerService(ConfigurationLoader configurationLoader, JsonLdTransform jsonLdTransform) {
     this.configurationLoader = configurationLoader;
+    this.jsonLdTransform = jsonLdTransform;
   }
   
   
@@ -57,12 +59,13 @@ public class ResponseTransformerService {
         return olsTransformer.constructResponse(transformedResults, responseMapping.getKey(), isList, paginate, page, totalCount);
       }
       case "ontoportal":
-        OntoPortalTransformer ontoPortalTransformer = new OntoPortalTransformer();
+        Map<String, Object> contextConfig = databaseConfig.getServiceConfig().getContext();
+        OntoPortalTransformer ontoPortalTransformer = new OntoPortalTransformer(contextConfig, jsonLdTransform);
         List<Map<String, Object>> transformedResultsOntoPortal = originalResponse.stream()
                 .map(x -> ontoPortalTransformer.transformItem(x, databaseConfig.getResponseMapping(endpoint)))
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
-        
+
         return ontoPortalTransformer.constructResponse(transformedResultsOntoPortal, null, false, paginate, page, totalCount);
       case "skosmos":
         SkosmosTransformer skosmosTransformer = new SkosmosTransformer();

--- a/src/main/resources/backend_types/ontoportal.yml
+++ b/src/main/resources/backend_types/ontoportal.yml
@@ -1,5 +1,28 @@
 name: ontoportal
 
+context:
+  vocab: "http://data.bioontology.org/metadata/"
+  language: "en"
+  fieldMappings:
+    prefLabel: label
+    synonym: synonyms
+    definition: descriptions
+    obsolete: obsolete
+  fieldOverrides:
+    definition: "http://www.w3.org/2004/02/skos/core#definition"
+  links:
+    self: "http://www.w3.org/2002/07/owl#Class"
+    ontology: "http://data.bioontology.org/metadata/Ontology"
+    children: "http://www.w3.org/2002/07/owl#Class"
+    parents: "http://www.w3.org/2002/07/owl#Class"
+    descendants: "http://www.w3.org/2002/07/owl#Class"
+    ancestors: "http://www.w3.org/2002/07/owl#Class"
+    instances: "http://data.bioontology.org/metadata/Instance"
+    tree: "http://www.w3.org/2002/07/owl#Class"
+    notes: "http://data.bioontology.org/metadata/Note"
+    mappings: "http://data.bioontology.org/metadata/Mapping"
+    ui: "http://www.w3.org/2002/07/owl#Class"
+
 pagination:
   type: page
   first: 1
@@ -58,14 +81,17 @@ models:
 
   searchResult: &searchResult
     <<: *term
+    matchType: matchType
+    ontologyType: ontologyType
 
 
 endpoints:
   search:
-    path: /search?q=%s&apikey=%s
+    path: /search?q=%s&pagesize=150&apikey=%s
     responseMapping:
       nestedJson: collection
       collectionFilter: ontologies
+      totalCount: totalCount
       <<: *searchResult
 
   resources:


### PR DESCRIPTION
**Summary**
- Fixed OntoPortal response format to match real API (prefLabel, synonym, definition, @id, @type, links, @context)
- Added matchType and ontologyType fields
- Increased pagesize to 150 and set totalCount to actual returned results
- Replaced alphabetic sort with cosine similarity sorting