### PR TITLE
Add timeout parameter

### DIFF
--- a/src/main/java/org/semantics/apigateway/artefacts/metadata/ArtefactsService.java
+++ b/src/main/java/org/semantics/apigateway/artefacts/metadata/ArtefactsService.java
@@ -90,7 +90,7 @@ public class ArtefactsService extends AbstractEndpointService {
         accessor = initAccessor(database, endpoint, accessor);
         accessor = applyCollection(accessor, collection, endpoint);
 
-        return accessor.get()
+        return accessor.get(params.getTimeout())
                 .thenApply(data -> this.transformApiResponses(data, endpoint))
                 .thenApply(transformedData -> flattenResponseList(transformedData, params, collection))
                 .thenApply(data -> filterOutByCollection(collection, data));

--- a/src/main/java/org/semantics/apigateway/artefacts/search/SearchService.java
+++ b/src/main/java/org/semantics/apigateway/artefacts/search/SearchService.java
@@ -61,7 +61,7 @@ public class SearchService extends AbstractEndpointService {
         accessor = applyCollection(accessor, collection, endpoint);
         
         try {
-            return accessor.get(query)
+            return accessor.get(params.getTimeout(), query)
                     .thenApply(data -> this.transformApiResponses(data, endpoint))
                     .thenApply(transformedData -> flattenResponseList(transformedData, params, collection))
                     .thenApply(data -> filterOutByCollection(collection, data))
@@ -103,7 +103,7 @@ public class SearchService extends AbstractEndpointService {
         // TODO add ontology parameter as soon as https://github.com/ts4nfdi/api-gateway/issues/123 has been resolved.
         
         try {
-            return accessor.get(query, "" + size, "" + offset)
+            return accessor.get(params.getTimeout(), query, "" + size, "" + offset)
                     .thenApply(data -> this.transformApiResponses(data, endpoint))
                     .thenApply(transformedData -> flattenResponseList(transformedData, params, collection))
                     .thenApply(data -> filterOutByCollection(collection, data))

--- a/src/main/java/org/semantics/apigateway/model/CommonRequestParams.java
+++ b/src/main/java/org/semantics/apigateway/model/CommonRequestParams.java
@@ -43,7 +43,6 @@ public class CommonRequestParams {
             array = @ArraySchema(schema = @Schema(type = "string")))
     private String display = "";
 
-
     public List<String> getDisplay() {
         List<String> result = new ArrayList<>();
 //        result.add("iri"); // TODO remove this if the TSS no more use it and instead use the @id
@@ -52,4 +51,9 @@ public class CommonRequestParams {
         }
         return result;
     }
+    
+    @QueryParam("timeout")
+    @Parameter(name = "timeout", in = ParameterIn.QUERY, description = "Set a timeout (in milliseconds) for the operation")
+    private long timeout = 60*1000;
+    
 }

--- a/src/main/java/org/semantics/apigateway/service/AbstractEndpointService.java
+++ b/src/main/java/org/semantics/apigateway/service/AbstractEndpointService.java
@@ -414,7 +414,7 @@ public abstract class AbstractEndpointService {
         List<String> ids = getRequestIds(accessor, acronym, uri);
         ids.add(page.toString());
 
-        return accessor.get(ids.toArray(new String[0]))
+        return accessor.get(params.getTimeout(), ids.toArray(new String[0]))
                 .thenApply(data -> this.transformApiResponses(data, endpoint, true))
                 .thenApply(data -> selectResultsByDatabase(data, database))
                 .thenApply(x -> paginate(x, params, page))
@@ -433,7 +433,7 @@ public abstract class AbstractEndpointService {
         accessor = initAccessor(database, endpoint, accessor);
         List<String> ids = getRequestIds(accessor, acronym, uri);
 
-        return accessor.get(ids.toArray(new String[0]))
+        return accessor.get(params.getTimeout(), ids.toArray(new String[0]))
                 .thenApply(data -> this.transformApiResponses(data, endpoint))
                 .thenApply(data -> selectResultsByDatabase(data, database))
                 .thenApply(data -> listResponse(data, params))
@@ -463,7 +463,7 @@ public abstract class AbstractEndpointService {
         accessor = initAccessor(database, endpoint, accessor);
         List<String> ids = getRequestIds(accessor, id, uri);
         try {
-            return accessor.get(ids.toArray(new String[0]))
+            return accessor.get(params.getTimeout(), ids.toArray(new String[0]))
                     .thenApply(data -> this.transformApiResponses(data, endpoint))
                     .thenApply(x -> filterById(x, ids))
                     .thenApply(data -> selectResultsByDatabase(data, database))

--- a/src/main/java/org/semantics/apigateway/service/ApiAccessor.java
+++ b/src/main/java/org/semantics/apigateway/service/ApiAccessor.java
@@ -16,6 +16,7 @@ import java.net.URL;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -44,12 +45,12 @@ public class ApiAccessor {
     }
 
     @Async
-    public CompletableFuture<Map<String, ApiResponse>> get() {
-        return get("");
+    public CompletableFuture<Map<String, ApiResponse>> get(long timeoutMillis) {
+        return get(timeoutMillis, "");
     }
 
     @Async
-    public CompletableFuture<Map<String, ApiResponse>> get(String... query) {
+    public CompletableFuture<Map<String, ApiResponse>> get(long timeoutMillis, String... query) {
         ForkJoinPool customThreadPool = new ForkJoinPool(Math.max(this.urls.size(), 1));
 
         List<CompletableFuture<Map.Entry<String, ApiResponse>>> futures = this.urls.entrySet().stream()
@@ -64,7 +65,7 @@ public class ApiAccessor {
                                 future -> future.join().getKey(),
                                 future -> future.join().getValue()
                         ))
-                )
+                ).completeOnTimeout(Map.of(), timeoutMillis, TimeUnit.MILLISECONDS)
                 .exceptionally(e -> {
                     logger.error("Error processing results: {}", e.getMessage(), e);
                     return Collections.emptyMap();


### PR DESCRIPTION
This PR adds a global timeout parameter to all endpoints (MOD and others like OLSV1/OLSV2).
The value is expected to be a number representing a timespan in milliseconds.
The parameter is optional. If omitted, a default value of 60.000 == 60 seconds is assumed.