### PR TITLE
Make collectionId a common request parameter and use it everywhere

### DIFF
--- a/src/main/java/org/semantics/apigateway/artefacts/data/ArtefactsDataController.java
+++ b/src/main/java/org/semantics/apigateway/artefacts/data/ArtefactsDataController.java
@@ -3,6 +3,7 @@ package org.semantics.apigateway.artefacts.data;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.semantics.apigateway.model.CommonRequestParams;
+import org.semantics.apigateway.service.auth.AuthService;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,68 +16,70 @@ import java.util.concurrent.ExecutionException;
 @Tag(name = "Artefacts / Data")
 public class ArtefactsDataController {
     private final ArtefactsDataService artefactsService;
+    private final AuthService authService;
 
-    public ArtefactsDataController(ArtefactsDataService artefactsService) {
+    public ArtefactsDataController(ArtefactsDataService artefactsService,  AuthService authService) {
         this.artefactsService = artefactsService;
+        this.authService = authService;
     }
 
     @GetMapping(value = {"/resources/classes", "/resources/concepts"})
     @Operation(summary = "Get a list of all owl:Classes or skos:Concepts within an artefact.")
-    public Object getArtefactTerms(@PathVariable String id, @RequestParam(required = false, defaultValue = "1") Integer page, @ParameterObject CommonRequestParams params) throws ExecutionException, InterruptedException {
-        return this.artefactsService.getArtefactTerms(id, params, page, null);
+    public Object getArtefactTerms(@PathVariable String id, @RequestParam(required = false, defaultValue = "1") Integer page, @ParameterObject CommonRequestParams params) {
+        return this.artefactsService.getArtefactTerms(id, params, page, null, authService.tryGetCurrentUser());
     }
 
     @GetMapping(value = {"/resources/properties"})
     @Operation(summary = "Get a list of all rdf:Property")
     public Object getProperties(@PathVariable String id, @ModelAttribute CommonRequestParams params, @RequestParam(required = false, defaultValue = "1") Integer page) {
-        return this.artefactsService.getArtefactProperties(id, params, page, null);
+        return this.artefactsService.getArtefactProperties(id, params, page, null, authService.tryGetCurrentUser());
     }
 
     @GetMapping(value = {"/resources/individuals"})
     @Operation(summary = "Get a list of all owl:Instance")
     public Object getIndividuals(@PathVariable String id, @ModelAttribute CommonRequestParams params, @RequestParam(required = false, defaultValue = "1") Integer page) {
-        return this.artefactsService.getArtefactIndividuals(id, params, page, null);
+        return this.artefactsService.getArtefactIndividuals(id, params, page, null, authService.tryGetCurrentUser());
     }
 
     @GetMapping(value = { "/resources/classes/{uri}", "/resources/concepts/{uri}"})
     @Operation(summary = "Get a list of all owl:Classes or skos:Concepts within an artefact.")
     public Object getArtefactTerms(@PathVariable String id, @PathVariable String uri, @ParameterObject CommonRequestParams params) {
-        return this.artefactsService.getArtefactTerm(id, uri, params, null);
+        return this.artefactsService.getArtefactTerm(id, uri, params, null, authService.tryGetCurrentUser());
     }
 
     @GetMapping(value = {"/resources/properties/{uri}"})
     @Operation(summary = "Get an rdf:Property details")
     public Object getPropertyDetails(@PathVariable String id, @PathVariable String uri, @ParameterObject CommonRequestParams params) {
-        return this.artefactsService.getArtefactProperty(id, uri, params, null);
+        return this.artefactsService.getArtefactProperty(id, uri, params, null, authService.tryGetCurrentUser());
     }
 
     @GetMapping(value = {"/resources/individuals/{uri}"})
     @Operation(summary = "Get an owl:Instance details")
     public Object getIndividualDetails(@PathVariable String id, @PathVariable String uri, @ParameterObject CommonRequestParams params) {
-        return this.artefactsService.getArtefactIndividual(id, uri, params, null);
+        return this.artefactsService.getArtefactIndividual(id, uri, params, null, authService.tryGetCurrentUser());
     }
 
     @GetMapping(value = { "/resources/schemes"})
     @Operation(summary = "Get a list of all skos:ConceptSchemes within an artefact.")
     public Object getSchemes(@PathVariable String id, @ParameterObject CommonRequestParams params, @RequestParam(required = false, defaultValue = "1") Integer page) {
-        return this.artefactsService.getArtefactSchemes(id, params, page, null);
+        return this.artefactsService.getArtefactSchemes(id, params, page, null, authService.tryGetCurrentUser());
     }
 
     @GetMapping(value = {"/resources/schemes/{uri}"})
     @Operation(summary = "Get a skos:ConceptScheme details")
     public Object getSchemeDetails(@PathVariable String id, @PathVariable String uri, @ParameterObject CommonRequestParams params) {
-        return this.artefactsService.getArtefactScheme(id, uri, params, null);
+        return this.artefactsService.getArtefactScheme(id, uri, params, null, authService.tryGetCurrentUser());
     }
 
     @GetMapping(value = {"/resources/collections"})
     @Operation(summary = "Get a list of all skos:Collections within an artefact.")
     public Object getCollections(@PathVariable String id, @ParameterObject CommonRequestParams params, @RequestParam(required = false, defaultValue = "1") Integer page) {
-        return this.artefactsService.getArtefactCollections(id, params, page, null);
+        return this.artefactsService.getArtefactCollections(id, params, page, null, authService.tryGetCurrentUser());
     }
 
     @GetMapping(value = { "/resources/collections/{uri}"})
     @Operation(summary = "Get a skos:Collection details")
     public Object getCollectionDetails(@PathVariable String id, @PathVariable String uri, @ParameterObject CommonRequestParams params) {
-        return this.artefactsService.getArtefactCollection(id, uri, params, null);
+        return this.artefactsService.getArtefactCollection(id, uri, params, null, authService.tryGetCurrentUser());
     }
 }

--- a/src/main/java/org/semantics/apigateway/artefacts/data/ArtefactsDataService.java
+++ b/src/main/java/org/semantics/apigateway/artefacts/data/ArtefactsDataService.java
@@ -1,7 +1,9 @@
 package org.semantics.apigateway.artefacts.data;
 
+import org.semantics.apigateway.collections.CollectionService;
 import org.semantics.apigateway.model.CommonRequestParams;
 import org.semantics.apigateway.model.RDFResource;
+import org.semantics.apigateway.model.user.User;
 import org.semantics.apigateway.service.AbstractEndpointService;
 import org.semantics.apigateway.service.ApiAccessor;
 import org.semantics.apigateway.service.JsonLdTransform;
@@ -15,49 +17,49 @@ import org.springframework.stereotype.Service;
 public class ArtefactsDataService extends AbstractEndpointService {
 
 
-    public ArtefactsDataService(ConfigurationLoader configurationLoader, CacheManager cacheManager, JsonLdTransform transform, ResponseTransformerService responseTransformerService) {
-        super(configurationLoader, cacheManager, transform, responseTransformerService, RDFResource.class);
+    public ArtefactsDataService(ConfigurationLoader configurationLoader, CacheManager cacheManager, JsonLdTransform transform, ResponseTransformerService responseTransformerService, CollectionService collectionService) {
+        super(configurationLoader, cacheManager, transform, responseTransformerService, collectionService, RDFResource.class);
     }
 
-    public Object getArtefactTerm(String id, String uri, CommonRequestParams params, ApiAccessor accessor) {
-        return findUri(id, uri, "concept_details", params, accessor);
+    public Object getArtefactTerm(String id, String uri, CommonRequestParams params, ApiAccessor accessor, User currentUser) {
+        return findUri(id, uri, "concept_details", params, accessor, currentUser);
     }
 
-    public Object getArtefactTerms(String id,CommonRequestParams params, Integer page, ApiAccessor accessor) {
-        return paginatedList(id, "concepts", params, page, accessor);
+    public Object getArtefactTerms(String id,CommonRequestParams params, Integer page, ApiAccessor accessor, User currentUser) {
+        return paginatedList(id, "concepts", params, page, accessor, currentUser);
     }
 
-    public Object getArtefactProperty(String id, String uri, CommonRequestParams params, ApiAccessor accessor) {
-        return findUri(id, uri, "property_details", params, accessor);
+    public Object getArtefactProperty(String id, String uri, CommonRequestParams params, ApiAccessor accessor, User currentUser) {
+        return findUri(id, uri, "property_details", params, accessor, currentUser);
     }
 
-    public Object getArtefactProperties(String id, CommonRequestParams params, Integer page, ApiAccessor accessor) {
-        return paginatedList(id, "properties", params, page, accessor);
+    public Object getArtefactProperties(String id, CommonRequestParams params, Integer page, ApiAccessor accessor, User currentUser) {
+        return paginatedList(id, "properties", params, page, accessor, currentUser);
     }
 
-    public Object getArtefactIndividual(String id, String uri, CommonRequestParams params, ApiAccessor accessor) {
-        return findUri(id, uri, "individual_details", params, accessor);
+    public Object getArtefactIndividual(String id, String uri, CommonRequestParams params, ApiAccessor accessor, User currentUser) {
+        return findUri(id, uri, "individual_details", params, accessor, currentUser);
     }
 
-    public Object getArtefactIndividuals(String id, CommonRequestParams params, Integer page, ApiAccessor accessor) {
-        return paginatedList(id, "individuals", params, page, accessor);
+    public Object getArtefactIndividuals(String id, CommonRequestParams params, Integer page, ApiAccessor accessor, User currentUser) {
+        return paginatedList(id, "individuals", params, page, accessor, currentUser);
     }
 
 
-    public Object getArtefactSchemes(String id, CommonRequestParams params, Integer page, ApiAccessor accessor) {
-        return paginatedList(id, "schemes", params, page, accessor);
+    public Object getArtefactSchemes(String id, CommonRequestParams params, Integer page, ApiAccessor accessor, User currentUser) {
+        return paginatedList(id, "schemes", params, page, accessor, currentUser);
     }
 
-    public Object getArtefactScheme(String id, String uri, CommonRequestParams params, ApiAccessor accessor) {
-        return findUri(id, uri, "scheme_details", params, accessor);
+    public Object getArtefactScheme(String id, String uri, CommonRequestParams params, ApiAccessor accessor, User currentUser) {
+        return findUri(id, uri, "scheme_details", params, accessor, currentUser);
     }
 
-    public Object getArtefactCollections(String id, CommonRequestParams params, Integer page, ApiAccessor accessor) {
-        return paginatedList(id, "collections", params, page, accessor);
+    public Object getArtefactCollections(String id, CommonRequestParams params, Integer page, ApiAccessor accessor, User currentUser) {
+        return paginatedList(id, "collections", params, page, accessor, currentUser);
     }
 
-    public Object getArtefactCollection(String id, String uri, CommonRequestParams params, ApiAccessor accessor) {
-        return findUri(id, uri, "collection_details", params, accessor);
+    public Object getArtefactCollection(String id, String uri, CommonRequestParams params, ApiAccessor accessor, User currentUser) {
+        return findUri(id, uri, "collection_details", params, accessor, currentUser);
     }
 }
 

--- a/src/main/java/org/semantics/apigateway/artefacts/metadata/ArtefactsController.java
+++ b/src/main/java/org/semantics/apigateway/artefacts/metadata/ArtefactsController.java
@@ -9,8 +9,6 @@ import org.semantics.apigateway.service.auth.AuthService;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.concurrent.ExecutionException;
-
 
 @RestController
 @RequestMapping("/")
@@ -37,7 +35,7 @@ public class ArtefactsController {
     @GetMapping("/artefacts/{id}")
     @Operation(summary = "Get information about a semantic artefact.")
     public Object getArtefact(@PathVariable("id") String id, @ParameterObject CommonRequestParams params) {
-        return this.artefactsService.getArtefact(id, params, null);
+        return this.artefactsService.getArtefact(id, params, null, authService.tryGetCurrentUser());
     }
 
 }

--- a/src/main/java/org/semantics/apigateway/artefacts/metadata/ArtefactsController.java
+++ b/src/main/java/org/semantics/apigateway/artefacts/metadata/ArtefactsController.java
@@ -1,7 +1,6 @@
 package org.semantics.apigateway.artefacts.metadata;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.semantics.apigateway.model.CommonRequestParams;
@@ -30,10 +29,9 @@ public class ArtefactsController {
     @GetMapping("/artefacts")
     @Operation(summary = "Get information about all semantic artefacts.")
     @SecurityRequirement(name = "BearerAuth")
-    public Object getArtefacts(@ParameterObject CommonRequestParams params,
-                                          @Parameter(description = "Collection id to browse terminologies in") @RequestParam(required = false) String collectionId) throws ExecutionException, InterruptedException {
+    public Object getArtefacts(@ParameterObject CommonRequestParams params) {
         User user = authService.tryGetCurrentUser();
-        return this.artefactsService.getArtefacts(params, collectionId, user, null);
+        return this.artefactsService.getArtefacts(params, user, null);
     }
 
     @GetMapping("/artefacts/{id}")

--- a/src/main/java/org/semantics/apigateway/artefacts/metadata/ArtefactsService.java
+++ b/src/main/java/org/semantics/apigateway/artefacts/metadata/ArtefactsService.java
@@ -31,11 +31,11 @@ public class ArtefactsService extends AbstractEndpointService {
     }
 
 
-    public Object getArtefacts(CommonRequestParams params, String collectionId, User currentUser, ApiAccessor accessor) {
+    public Object getArtefacts(CommonRequestParams params, User currentUser, ApiAccessor accessor) {
         String endpoint = "resources";
         try {
             return
-                    findAllArtefacts(params, collectionId, currentUser, accessor)
+                    findAllArtefacts(params, currentUser, accessor)
                             .thenApply(data -> transformJsonLd(data, params))
                             .thenApply(data -> transformForTargetDbSchema(data, params.getTargetDbSchema(), endpoint)).get();
         } catch (InterruptedException | ExecutionException e) {
@@ -52,7 +52,7 @@ public class ArtefactsService extends AbstractEndpointService {
 
     public Object searchMetadata(String query, CommonRequestParams params, ApiAccessor accessor) {
         String endpoint = "resources";
-        return findAllArtefacts(params, null, null, accessor)
+        return findAllArtefacts(params, null, accessor)
                 .thenApply(data -> filterOutByQuery(query, data))
                 .thenApply(x -> transformJsonLd(x, params))
                 .thenApply(data -> transformForTargetDbSchema(data, params.getTargetDbSchema(), endpoint));
@@ -82,10 +82,10 @@ public class ArtefactsService extends AbstractEndpointService {
         return data;
     }
 
-    private CompletableFuture<AggregatedApiResponse> findAllArtefacts(CommonRequestParams params, String collectionId, User currentUser, ApiAccessor accessor) {
+    private CompletableFuture<AggregatedApiResponse> findAllArtefacts(CommonRequestParams params, User currentUser, ApiAccessor accessor) {
         String endpoint = "resources";
         String database = params.getDatabase();
-        TerminologyCollection collection = collectionService.getCurrentUserCollection(collectionId, currentUser);
+        TerminologyCollection collection = collectionService.getCurrentUserCollection(params.getCollectionId(), currentUser);
 
         accessor = initAccessor(database, endpoint, accessor);
         accessor = applyCollection(accessor, collection, endpoint);

--- a/src/main/java/org/semantics/apigateway/artefacts/metadata/ArtefactsService.java
+++ b/src/main/java/org/semantics/apigateway/artefacts/metadata/ArtefactsService.java
@@ -23,13 +23,9 @@ import java.util.concurrent.ExecutionException;
 @Service
 public class ArtefactsService extends AbstractEndpointService {
 
-    private final CollectionService collectionService;
-
     public ArtefactsService(ConfigurationLoader configurationLoader, CacheManager cacheManager, JsonLdTransform transform, ResponseTransformerService responseTransformerService, CollectionService collectionService) {
-        super(configurationLoader, cacheManager, transform, responseTransformerService, SemanticArtefact.class);
-        this.collectionService = collectionService;
+        super(configurationLoader, cacheManager, transform, responseTransformerService, collectionService, SemanticArtefact.class);
     }
-
 
     public Object getArtefacts(CommonRequestParams params, User currentUser, ApiAccessor accessor) {
         String endpoint = "resources";
@@ -45,8 +41,8 @@ public class ArtefactsService extends AbstractEndpointService {
     }
 
 
-    public Object getArtefact(String id, CommonRequestParams params, ApiAccessor accessor) {
-        return findUri(id, null, "resource_details", params, accessor);
+    public Object getArtefact(String id, CommonRequestParams params, ApiAccessor accessor, User currentUser) {
+        return findUri(id, null, "resource_details", params, accessor, currentUser);
     }
 
 

--- a/src/main/java/org/semantics/apigateway/artefacts/search/SearchController.java
+++ b/src/main/java/org/semantics/apigateway/artefacts/search/SearchController.java
@@ -34,12 +34,10 @@ public class SearchController {
     public Object search(
             @Parameter(description = "The text to search", example = "plant")
             @RequestParam String query,
-            @ParameterObject CommonRequestParams params,
-            @Parameter(description = "Collection id to search in")
-            @RequestParam(required = false) String collectionId
+            @ParameterObject CommonRequestParams params
     ) {
         User user = authService.tryGetCurrentUser();
-        return searchService.performSearch(query, params, collectionId, user, null);
+        return searchService.performSearch(query, params, user, null);
     }
 
 

--- a/src/main/java/org/semantics/apigateway/artefacts/search/SearchService.java
+++ b/src/main/java/org/semantics/apigateway/artefacts/search/SearchService.java
@@ -33,7 +33,7 @@ public class SearchService extends AbstractEndpointService {
     private final CollectionService collectionService;
 
     public SearchService(ConfigurationLoader configurationLoader, SearchLocalIndexerService localIndexer, CacheManager cacheManager, JsonLdTransform jsonLdTransform, ResponseTransformerService responseTransformerService, CollectionService collectionService) {
-        super(configurationLoader, cacheManager, jsonLdTransform, responseTransformerService, RDFResource.class);
+        super(configurationLoader, cacheManager, jsonLdTransform, responseTransformerService, collectionService, RDFResource.class);
         this.localIndexer = localIndexer;
         this.collectionService = collectionService;
     }

--- a/src/main/java/org/semantics/apigateway/artefacts/search/SearchService.java
+++ b/src/main/java/org/semantics/apigateway/artefacts/search/SearchService.java
@@ -38,26 +38,26 @@ public class SearchService extends AbstractEndpointService {
         this.collectionService = collectionService;
     }
 
-    public AggregatedApiResponse performSearch(String query, String database, String targetDbSchema, boolean showResponseConfiguration, long timeoutMillis) {
+    public AggregatedApiResponse performSearch(String query, String database, String targetDbSchema, String collectionId, boolean showResponseConfiguration, long timeoutMillis) {
         TargetDbSchema targetDbSchemaEnum = targetDbSchema == null ? null : TargetDbSchema.valueOf(targetDbSchema);
         CommonRequestParams commonRequestParams = new CommonRequestParams();
         commonRequestParams.setDatabase(database);
         commonRequestParams.setTargetDbSchema(targetDbSchemaEnum);
+        commonRequestParams.setCollectionId(collectionId);
         commonRequestParams.setShowResponseConfiguration(showResponseConfiguration);
         commonRequestParams.setTimeout(timeoutMillis);
-        return performSearch(query, commonRequestParams, null, null, null);
+        return  performSearch(query, commonRequestParams, null, null);
     }
     
     public AggregatedApiResponse performSearch(
             String query,
             CommonRequestParams params,
-            String collectionId,
             User currentUser,
             ApiAccessor accessor) {
         String endpoint = "search";
         String database = params.getDatabase();
         TargetDbSchema targetDbSchema = params.getTargetDbSchema();
-        TerminologyCollection collection = collectionService.getCurrentUserCollection(collectionId, currentUser);
+        TerminologyCollection collection = collectionService.getCurrentUserCollection(params.getCollectionId(), currentUser);
         accessor = initAccessor(database, endpoint, accessor);
         accessor = applyCollection(accessor, collection, endpoint);
         
@@ -82,7 +82,7 @@ public class SearchService extends AbstractEndpointService {
             int offset,
             int size,
             CommonRequestParams params) {
-        return suggestConcepts(id, query, offset, size, params, null, null, null);
+        return suggestConcepts(id, query, offset, size, params, null, null);
     }
     
     public AggregatedApiResponse suggestConcepts(
@@ -91,13 +91,12 @@ public class SearchService extends AbstractEndpointService {
             int offset,
             int size,
             CommonRequestParams params,
-            String collectionId,
             User currentUser,
             ApiAccessor accessor) {
         String endpoint = "suggest";
         String database = params.getDatabase();
         TargetDbSchema targetDbSchema = params.getTargetDbSchema();
-        TerminologyCollection collection = collectionService.getCurrentUserCollection(collectionId, currentUser);
+        TerminologyCollection collection = collectionService.getCurrentUserCollection(params.getCollectionId(), currentUser);
         accessor = initAccessor(database, endpoint, accessor);
         accessor = applyCollection(accessor, collection, endpoint);
         

--- a/src/main/java/org/semantics/apigateway/artefacts/tree/ArtefactsDataTreeController.java
+++ b/src/main/java/org/semantics/apigateway/artefacts/tree/ArtefactsDataTreeController.java
@@ -3,6 +3,7 @@ package org.semantics.apigateway.artefacts.tree;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.semantics.apigateway.model.CommonRequestParams;
+import org.semantics.apigateway.service.auth.AuthService;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,15 +16,17 @@ import java.net.URLEncoder;
 @Tag(name = "Artefacts / Data")
 public class ArtefactsDataTreeController {
     private final ArtefactsDataTreeService artefactsService;
+    private final AuthService authService;
 
-    public ArtefactsDataTreeController(ArtefactsDataTreeService artefactsService) {
+    public ArtefactsDataTreeController(ArtefactsDataTreeService artefactsService,  AuthService authService) {
         this.artefactsService = artefactsService;
+        this.authService = authService;
     }
 
     @GetMapping(value = {"/resources/concepts/roots", "/resources/classes/roots"})
     @Operation(summary = "Get a list of all roots in an artefact.")
     public Object getArtefactRoots(@PathVariable String id, @ParameterObject CommonRequestParams params) {
-        return this.artefactsService.getRoots(id, params, null);
+        return this.artefactsService.getRoots(id, params, null, authService.tryGetCurrentUser());
     }
 
     @GetMapping(value = {"/resources/classes/children", "/resources/concepts/children"})
@@ -31,7 +34,7 @@ public class ArtefactsDataTreeController {
     public Object getConceptChildren(@PathVariable String id, @RequestParam String uri, @ModelAttribute CommonRequestParams params,
                                      @RequestParam(required = false, defaultValue = "1") Integer page) {
         uri = URLEncoder.encode(uri);
-        return this.artefactsService.getChildren(id, uri, params, page, null);
+        return this.artefactsService.getChildren(id, uri, params, page, null, authService.tryGetCurrentUser());
     }
 
 
@@ -40,6 +43,6 @@ public class ArtefactsDataTreeController {
     @Operation(summary = "Get a full tree of all children of a specific owl:Class or skos:Concept within an artefact.")
     public Object getConceptFullTree(@PathVariable String id, @RequestParam String uri, @ModelAttribute CommonRequestParams params) {
         uri = URLEncoder.encode(uri);
-        return this.artefactsService.getTree(id, uri, params, null);
+        return this.artefactsService.getTree(id, uri, params, null, authService.tryGetCurrentUser());
     }
 }

--- a/src/main/java/org/semantics/apigateway/artefacts/tree/ArtefactsDataTreeService.java
+++ b/src/main/java/org/semantics/apigateway/artefacts/tree/ArtefactsDataTreeService.java
@@ -1,11 +1,13 @@
 package org.semantics.apigateway.artefacts.tree;
 
+import org.semantics.apigateway.collections.CollectionService;
 import org.semantics.apigateway.config.DatabaseConfig;
 import org.semantics.apigateway.model.CommonRequestParams;
 import org.semantics.apigateway.model.Endpoints;
 import org.semantics.apigateway.model.RDFResource;
 import org.semantics.apigateway.model.responses.AggregatedApiResponse;
 import org.semantics.apigateway.model.responses.AggregatedResourceBody;
+import org.semantics.apigateway.model.user.User;
 import org.semantics.apigateway.service.AbstractEndpointService;
 import org.semantics.apigateway.service.ApiAccessor;
 import org.semantics.apigateway.service.JsonLdTransform;
@@ -25,23 +27,23 @@ import java.util.Map;
 public class ArtefactsDataTreeService extends AbstractEndpointService {
 
 
-    public ArtefactsDataTreeService(ConfigurationLoader configurationLoader, CacheManager cacheManager, JsonLdTransform transform, ResponseTransformerService responseTransformerService) {
-        super(configurationLoader, cacheManager, transform, responseTransformerService, RDFResource.class);
+    public ArtefactsDataTreeService(ConfigurationLoader configurationLoader, CacheManager cacheManager, JsonLdTransform transform, ResponseTransformerService responseTransformerService, CollectionService collectionService) {
+        super(configurationLoader, cacheManager, transform, responseTransformerService, collectionService, RDFResource.class);
     }
 
-    public Object getRoots(String acronym, CommonRequestParams params, ApiAccessor accessor) {
+    public Object getRoots(String acronym, CommonRequestParams params, ApiAccessor accessor, User currentUser) {
         if (acronym == null || acronym.isEmpty()) {
             return new AggregatedApiResponse();
         }
         String endpoint = Endpoints.concepts_roots.toString();
         accessor = initAccessor(params.getDatabase(), endpoint, accessor);
-        return findAll(acronym, endpoint, params, accessor).thenApply(x -> {
-            x.setCollection(sortChildren((List<Map<String, Object>>) x.getCollection()));
+        return findAll(acronym, endpoint, params, accessor, currentUser).thenApply(x -> {
+            x.setCollection(sortChildren(x.getCollection()));
             return x;
         });
     }
 
-    public Object getChildren(String acronym, String uri, CommonRequestParams params, Integer page, ApiAccessor accessor) {
+    public Object getChildren(String acronym, String uri, CommonRequestParams params, Integer page, ApiAccessor accessor,  User currentUser) {
         if (acronym == null || acronym.isEmpty() || uri == null || uri.isEmpty()) {
             return Collections.EMPTY_LIST;
         }
@@ -52,10 +54,10 @@ public class ArtefactsDataTreeService extends AbstractEndpointService {
         if (databaseConfig.isOls2()) {
             uri = URLEncoder.encode(URLEncoder.encode(uri)); // OLS2 requires URI double encoding
         }
-        return paginatedList(acronym, uri, endpoint, params, page, accessor);
+        return paginatedList(acronym, uri, endpoint, params, page, accessor,  currentUser);
     }
 
-    public Object getTree(String acronym, String uri, CommonRequestParams params, ApiAccessor accessor) {
+    public Object getTree(String acronym, String uri, CommonRequestParams params, ApiAccessor accessor, User currentUser) {
         if (acronym == null || acronym.isEmpty() || uri == null || uri.isEmpty()) {
             return Collections.EMPTY_LIST;
         }
@@ -67,15 +69,15 @@ public class ArtefactsDataTreeService extends AbstractEndpointService {
             finalUri = URLEncoder.encode(URLEncoder.encode(uri)); // OLS2 requires URI double encoding
         }
 
-        return findAll(acronym, finalUri, endpoint, params, accessor)
-                .thenApply(data -> databaseConfig.isOls() ? buildOlsTree(data, acronym, uri, params) : data)
+        return findAll(acronym, finalUri, endpoint, params, accessor, currentUser)
+                .thenApply(data -> databaseConfig.isOls() ? buildOlsTree(data, acronym, uri, params, currentUser) : data)
                 .thenApply(data -> databaseConfig.isOntoPortal() ? transformAllNestedChildren(data, databaseConfig, endpoint) : data);
     }
 
-    private AggregatedApiResponse buildOlsTree(AggregatedApiResponse data, String acronym, String uri, CommonRequestParams params) {
+    private AggregatedApiResponse buildOlsTree(AggregatedApiResponse data, String acronym, String uri, CommonRequestParams params, User currentUser) {
         List<Map<String, Object>> pathToRoot = data.getCollection();
         List<Map<String, Object>> cleanedPath = new ArrayList<>();
-        Map<String, Object> leafNode = findUri(acronym, uri, Endpoints.concept_details.toString(), params, null).getCollection().get(0);
+        Map<String, Object> leafNode = findUri(acronym, uri, Endpoints.concept_details.toString(), params, null, currentUser).getCollection().get(0);
 
         for (Map<String, Object> child : pathToRoot) {
             if (child.get("iri").equals("http://www.w3.org/2002/07/owl#Thing")) {

--- a/src/main/java/org/semantics/apigateway/controller/ols/Ols3Controller.java
+++ b/src/main/java/org/semantics/apigateway/controller/ols/Ols3Controller.java
@@ -1,6 +1,5 @@
 package org.semantics.apigateway.controller.ols;
 
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.ws.rs.QueryParam;
 import org.semantics.apigateway.artefacts.data.ArtefactsDataService;
@@ -56,7 +55,7 @@ public class Ols3Controller {
       timeout = 60 * 1000;
     }
     
-    AggregatedApiResponse response = searchService.performSearch(query + "*", allParams.get("ontology"), "ols", false, timeout);
+    AggregatedApiResponse response = searchService.performSearch(query + "*", allParams.get("ontology"), "ols", allParams.get("collectionId"), false, timeout);
     return response.getCollection().get(0);
   }
   
@@ -68,7 +67,7 @@ public class Ols3Controller {
   
   @CrossOrigin
   @GetMapping("/terms")
-  public Object getAllTermsInOLSTargetDBSchema(@RequestParam(required = false, defaultValue = "0") Integer page, @QueryParam("iri") String iri, @ParameterObject CommonRequestParams params, @RequestParam(required = false) String collectionId) {
+  public Object getAllTermsInOLSTargetDBSchema(@RequestParam(required = false, defaultValue = "0") Integer page, @QueryParam("iri") String iri, @ParameterObject CommonRequestParams params) {
     if (iri != null) {
       return this.artefactsDataService.getArtefactTerms(iri, params, page + 1, null);
     }
@@ -92,10 +91,9 @@ public class Ols3Controller {
   
   @CrossOrigin
   @GetMapping("/ontologies")
-  public Object getArtefactsInOLSTargetDBSchema(@ParameterObject CommonRequestParams params,
-                                                @Parameter(description = "Collection id to browse terminologies in") @RequestParam(required = false) String collectionId) {
+  public Object getArtefactsInOLSTargetDBSchema(@ParameterObject CommonRequestParams params) {
     User user = authService.tryGetCurrentUser();
-    return this.artefactsService.getArtefacts(params, collectionId, user, null);
+    return this.artefactsService.getArtefacts(params, user, null);
   }
 }
 

--- a/src/main/java/org/semantics/apigateway/controller/ols/Ols3Controller.java
+++ b/src/main/java/org/semantics/apigateway/controller/ols/Ols3Controller.java
@@ -69,24 +69,24 @@ public class Ols3Controller {
   @GetMapping("/terms")
   public Object getAllTermsInOLSTargetDBSchema(@RequestParam(required = false, defaultValue = "0") Integer page, @QueryParam("iri") String iri, @ParameterObject CommonRequestParams params) {
     if (iri != null) {
-      return this.artefactsDataService.getArtefactTerms(iri, params, page + 1, null);
+      return this.artefactsDataService.getArtefactTerms(iri, params, page + 1, null, authService.tryGetCurrentUser());
     }
-    return this.artefactsDataService.getArtefactTerms("", params, page + 1, null);
+    return this.artefactsDataService.getArtefactTerms("", params, page + 1, null, authService.tryGetCurrentUser());
   }
   
   @CrossOrigin
   @GetMapping("/ontologies/{onto}/terms")
   public Object getTermsInOLSTargetDBSchema(@PathVariable String onto, @RequestParam(required = false, defaultValue = "1") Integer page, @QueryParam("iri") String iri, @ParameterObject CommonRequestParams params) {
     if (iri != null) {
-      return this.artefactsDataService.getArtefactTerm(onto, iri, params, null);
+      return this.artefactsDataService.getArtefactTerm(onto, iri, params, null, authService.tryGetCurrentUser());
     }
-    return this.artefactsDataService.getArtefactTerms(onto, params, page + 1, null);
+    return this.artefactsDataService.getArtefactTerms(onto, params, page + 1, null, authService.tryGetCurrentUser());
   }
   
   @CrossOrigin
   @GetMapping("/ontologies/{onto}")
   public Object getArtefactMetadataInOLSTargetDBSchema(@PathVariable String onto, @ParameterObject CommonRequestParams params) {
-    return this.artefactsService.getArtefact(onto, params, null);
+    return this.artefactsService.getArtefact(onto, params, null, authService.tryGetCurrentUser());
   }
   
   @CrossOrigin

--- a/src/main/java/org/semantics/apigateway/controller/ols/Ols4Controller.java
+++ b/src/main/java/org/semantics/apigateway/controller/ols/Ols4Controller.java
@@ -18,8 +18,6 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Collections;
-
 @Component
 @RestController
 @RequestMapping(value={"/ols/api/v2", "/ols4/api/v2"})
@@ -32,7 +30,7 @@ public class Ols4Controller {
   private final AuthService authService;
   private final ArtefactsDataTreeService treeService;
   
-  private OlsV2Transformer olsV2Transformer = new OlsV2Transformer(); // TODO This breaks decoupling. Better pass original request through the services, so that we know how to construct the response in the transformers.
+  private final OlsV2Transformer olsV2Transformer = new OlsV2Transformer(); // TODO This breaks decoupling. Better pass original request through the services, so that we know how to construct the response in the transformers.
   
   public Ols4Controller(SearchService searchService, ArtefactsService artefactsService, ArtefactsDataService artefactsDataService, AuthService authService, ArtefactsDataTreeService treeService) {
     this.artefactsService = artefactsService;
@@ -50,7 +48,7 @@ public class Ols4Controller {
   @CrossOrigin
   @GetMapping("/ontologies/{onto}")
   public Object getOntologyInOLSTargetDBSchema(@PathVariable String onto, @ParameterObject CommonRequestParams params) {
-    return artefactsService.getArtefact(onto, params, null);
+    return artefactsService.getArtefact(onto, params, null, authService.tryGetCurrentUser());
   }
   
   @CrossOrigin
@@ -62,15 +60,15 @@ public class Ols4Controller {
   @CrossOrigin
   @GetMapping("/ontologies/{onto}/individuals")
   public Object getAllIndividualsForOntologyInOLSTargetDBSchema(@PathVariable String onto, @ParameterObject CommonRequestParams params, CommonOLS4Params ols4Params, @PageableDefault(page = 0, size = 20) Pageable pageable, @QueryParam("iri") String iri) {
-    if (iri == null) return artefactsDataService.getArtefactIndividuals(onto, params, pageable.getPageNumber() + 1, null);
-    AggregatedApiResponse response = (AggregatedApiResponse) artefactsDataService.getArtefactIndividual(onto, iri, params, null);
+    if (iri == null) return artefactsDataService.getArtefactIndividuals(onto, params, pageable.getPageNumber() + 1, null, authService.tryGetCurrentUser());
+    AggregatedApiResponse response = (AggregatedApiResponse) artefactsDataService.getArtefactIndividual(onto, iri, params, null, authService.tryGetCurrentUser());
     return olsV2Transformer.constructResponse(response.getCollection(), "concepts", true, true, 1, response.getCollection().size());
   }
   
   @CrossOrigin
   @GetMapping("/ontologies/{onto}/individuals/{individual}")
   public Object getIndividualForOntologyInOLSTargetDBSchema(@PathVariable String onto, @PathVariable String individual, @ParameterObject CommonRequestParams params) {
-    return artefactsDataService.getArtefactIndividual(onto, individual, params, null);
+    return artefactsDataService.getArtefactIndividual(onto, individual, params, null, authService.tryGetCurrentUser());
   }
   
   @CrossOrigin
@@ -83,23 +81,23 @@ public class Ols4Controller {
   @GetMapping("/individuals")
   public Object getAllIndividualsInOLSTargetDBSchema(@ParameterObject CommonRequestParams params, @ParameterObject CommonOLS4Params ols4Params, @PageableDefault(page = 0, size = 20) Pageable pageable, @QueryParam("iri") String iri) {
     if (iri != null) {
-      return this.artefactsDataService.getArtefactIndividuals(iri, params, pageable.getPageNumber() + 1, null);
+      return this.artefactsDataService.getArtefactIndividuals(iri, params, pageable.getPageNumber() + 1, null, authService.tryGetCurrentUser());
     }
-    return this.artefactsDataService.getArtefactIndividuals("", params, pageable.getPageNumber() + 1, null);
+    return this.artefactsDataService.getArtefactIndividuals("", params, pageable.getPageNumber() + 1, null, authService.tryGetCurrentUser());
   }
   
   @CrossOrigin
   @GetMapping("/ontologies/{onto}/entities")
   public Object getAllEntitiesForOntologyInOLSTargetDBSchema(@PathVariable String onto, @ParameterObject CommonRequestParams params, CommonOLS4Params ols4Params, @PageableDefault(page = 0, size = 20) Pageable pageable, @QueryParam("iri") String iri) {
-    if (iri == null) return artefactsDataService.getArtefactTerms(onto, params, pageable.getPageNumber() + 1, null);
-    AggregatedApiResponse response = (AggregatedApiResponse) artefactsDataService.getArtefactTerm(onto, iri, params, null);
+    if (iri == null) return artefactsDataService.getArtefactTerms(onto, params, pageable.getPageNumber() + 1, null, authService.tryGetCurrentUser());
+    AggregatedApiResponse response = (AggregatedApiResponse) artefactsDataService.getArtefactTerm(onto, iri, params, null, authService.tryGetCurrentUser());
     return olsV2Transformer.constructResponse(response.getCollection(), "concepts", true, true, 1, response.getCollection().size());
   }
   
   @CrossOrigin
   @GetMapping("/ontologies/{onto}/entities/{entity}")
   public Object getEntityInOLSTargetDBSchema(@PathVariable String onto, @PathVariable String entity, @ParameterObject CommonRequestParams params) {
-    return artefactsDataService.getArtefactTerm(onto, entity, params, null);
+    return artefactsDataService.getArtefactTerm(onto, entity, params, null, authService.tryGetCurrentUser());
   }
   
   @CrossOrigin
@@ -113,9 +111,9 @@ public class Ols4Controller {
   public Object getAllEntitiesInOLSTargetDBSchema(@ParameterObject CommonRequestParams params, @ParameterObject CommonOLS4Params ols4Params, @PageableDefault(page = 0, size = 20) Pageable pageable, @QueryParam("iri") String iri) {
     // TODO Is there a way to run a federated query over all endpoints and their respective artifacts for all entities? Improbable, solely for performance reasons.
     if (iri != null) {
-      return this.artefactsDataService.getArtefactTerms(iri, params, pageable.getPageNumber() + 1, null);
+      return this.artefactsDataService.getArtefactTerms(iri, params, pageable.getPageNumber() + 1, null, authService.tryGetCurrentUser());
     }
-    return this.artefactsDataService.getArtefactTerms("", params, pageable.getPageNumber() + 1, null);
+    return this.artefactsDataService.getArtefactTerms("", params, pageable.getPageNumber() + 1, null, authService.tryGetCurrentUser());
   }
   
   @CrossOrigin
@@ -127,15 +125,15 @@ public class Ols4Controller {
   @CrossOrigin
   @GetMapping("/ontologies/{onto}/classes")
   public Object getClassesInOLSTargetDBSchema(@PathVariable String onto, @ParameterObject CommonRequestParams params, @ParameterObject CommonOLS4Params ols4Params, @PageableDefault(page = 0, size = 20) Pageable pageable, @QueryParam("iri") String iri) {
-    if (iri == null) return artefactsDataService.getArtefactTerms(onto, params, pageable.getPageNumber() + 1, null);
-    AggregatedApiResponse response = (AggregatedApiResponse) artefactsDataService.getArtefactTerm(onto, iri, params, null);
+    if (iri == null) return artefactsDataService.getArtefactTerms(onto, params, pageable.getPageNumber() + 1, null, authService.tryGetCurrentUser());
+    AggregatedApiResponse response = (AggregatedApiResponse) artefactsDataService.getArtefactTerm(onto, iri, params, null, authService.tryGetCurrentUser());
     return olsV2Transformer.constructResponse(response.getCollection(), "concepts", true, true, 1, response.getCollection().size());
   }
   
   @CrossOrigin
   @GetMapping("/ontologies/{onto}/classes/{class}")
   public Object getClassInOLSTargetDBSchema(@PathVariable String onto, @PathVariable("class") String clazz, @ParameterObject CommonRequestParams params) {
-    return artefactsDataService.getArtefactTerm(onto, clazz, params, null);
+    return artefactsDataService.getArtefactTerm(onto, clazz, params, null, authService.tryGetCurrentUser());
   }
   
   @CrossOrigin
@@ -171,7 +169,7 @@ public class Ols4Controller {
   @CrossOrigin
   @GetMapping("/ontologies/{onto}/classes/{class}/children")
   public Object getClassChildrenInOLSTargetDBSchema(@PathVariable String onto, @PathVariable("class") String clazz, @ParameterObject CommonRequestParams params, @ParameterObject CommonOLS4Params ols4Params, @PageableDefault(page = 0, size = 20) Pageable pageable) {
-    return treeService.getChildren(onto, clazz, params, pageable.getPageNumber() + 1, null);
+    return treeService.getChildren(onto, clazz, params, pageable.getPageNumber() + 1, null, authService.tryGetCurrentUser());
   }
   
   @CrossOrigin
@@ -184,38 +182,38 @@ public class Ols4Controller {
   @GetMapping("/classes")
   public Object getAllClassesInOLSTargetDBSchema(@ParameterObject CommonRequestParams params, @ParameterObject CommonOLS4Params ols4Params, @PageableDefault(page = 0, size = 20) Pageable pageable, @QueryParam("iri") String iri) {
     if (iri != null) {
-      return this.artefactsDataService.getArtefactTerms(iri, params, pageable.getPageNumber() + 1, null);
+      return this.artefactsDataService.getArtefactTerms(iri, params, pageable.getPageNumber() + 1, null, authService.tryGetCurrentUser());
     }
-    return this.artefactsDataService.getArtefactTerms("", params, pageable.getPageNumber() + 1, null);
+    return this.artefactsDataService.getArtefactTerms("", params, pageable.getPageNumber() + 1, null, authService.tryGetCurrentUser());
   }
   
   @CrossOrigin
   @GetMapping("/properties")
   public Object getAllPropertiesInOLSTargetDBSchema(@ParameterObject CommonRequestParams params, @ParameterObject CommonOLS4Params ols4Params, @PageableDefault(page = 0, size = 20) Pageable pageable, @QueryParam("iri") String iri) {
     if (iri != null) {
-      return this.artefactsDataService.getArtefactProperties(iri, params, pageable.getPageNumber() + 1, null);
+      return this.artefactsDataService.getArtefactProperties(iri, params, pageable.getPageNumber() + 1, null, authService.tryGetCurrentUser());
     }
-    return this.artefactsDataService.getArtefactProperties("", params, pageable.getPageNumber() + 1, null);
+    return this.artefactsDataService.getArtefactProperties("", params, pageable.getPageNumber() + 1, null, authService.tryGetCurrentUser());
   }
   
   @CrossOrigin
   @GetMapping("/ontologies/{onto}/properties")
   public Object getPropertiesForOntologyInOLSTargetDBSchema(@PathVariable String onto, @ParameterObject CommonRequestParams params, @ParameterObject CommonOLS4Params ols4Params, @PageableDefault(page = 0, size = 20) Pageable pageable, @QueryParam("iri") String iri) {
-    if (iri == null) return artefactsDataService.getArtefactProperties(onto, params, pageable.getPageNumber() + 1, null);
-    AggregatedApiResponse response = (AggregatedApiResponse) artefactsDataService.getArtefactProperty(onto, iri, params, null);
+    if (iri == null) return artefactsDataService.getArtefactProperties(onto, params, pageable.getPageNumber() + 1, null, authService.tryGetCurrentUser());
+    AggregatedApiResponse response = (AggregatedApiResponse) artefactsDataService.getArtefactProperty(onto, iri, params, null, authService.tryGetCurrentUser());
     return olsV2Transformer.constructResponse(response.getCollection(), "concepts", true, true, 1, response.getCollection().size());
   }
   
   @CrossOrigin
   @GetMapping("/ontologies/{onto}/properties/{property}")
   public Object getPropertyInOLSTargetDBSchema(@PathVariable String onto, @PathVariable String property, @ParameterObject CommonRequestParams params) {
-    return  artefactsDataService.getArtefactProperty(onto, property, params, null);
+    return  artefactsDataService.getArtefactProperty(onto, property, params, null, authService.tryGetCurrentUser());
   }
   
   @CrossOrigin
   @GetMapping("/ontologies/{onto}/properties/{property}/children")
   public Object getPropertyChildenInOLSTargetDBSchema(@PathVariable String onto, @PathVariable String property, @ParameterObject CommonRequestParams params, @ParameterObject CommonOLS4Params ols4Params, @PageableDefault(page = 0, size = 20) Pageable pageable) {
-    return treeService.getChildren(onto, property, params, pageable.getPageNumber() + 1, null);
+    return treeService.getChildren(onto, property, params, pageable.getPageNumber() + 1, null, authService.tryGetCurrentUser());
   }
   
   @CrossOrigin

--- a/src/main/java/org/semantics/apigateway/controller/ols/Ols4Controller.java
+++ b/src/main/java/org/semantics/apigateway/controller/ols/Ols4Controller.java
@@ -43,8 +43,8 @@ public class Ols4Controller {
   
   @CrossOrigin
   @GetMapping("/ontologies")
-  public Object getAllOntologiesInOLSTargetDBSchema(@ParameterObject CommonRequestParams params, CommonOLS4Params ols4Params, @PageableDefault(page = 0, size = 20) Pageable pageable, @RequestParam(required = false) String collectionId) {
-    return artefactsService.getArtefacts(params, collectionId, authService.tryGetCurrentUser(), null);
+  public Object getAllOntologiesInOLSTargetDBSchema(@ParameterObject CommonRequestParams params, CommonOLS4Params ols4Params, @PageableDefault(page = 0, size = 20) Pageable pageable) {
+    return artefactsService.getArtefacts(params, authService.tryGetCurrentUser(), null);
   }
   
   @CrossOrigin
@@ -81,7 +81,7 @@ public class Ols4Controller {
   
   @CrossOrigin
   @GetMapping("/individuals")
-  public Object getAllIndividualsInOLSTargetDBSchema(@ParameterObject CommonRequestParams params, @ParameterObject CommonOLS4Params ols4Params, @PageableDefault(page = 0, size = 20) Pageable pageable, @RequestParam(required = false) String collectionId, @QueryParam("iri") String iri) {
+  public Object getAllIndividualsInOLSTargetDBSchema(@ParameterObject CommonRequestParams params, @ParameterObject CommonOLS4Params ols4Params, @PageableDefault(page = 0, size = 20) Pageable pageable, @QueryParam("iri") String iri) {
     if (iri != null) {
       return this.artefactsDataService.getArtefactIndividuals(iri, params, pageable.getPageNumber() + 1, null);
     }

--- a/src/main/java/org/semantics/apigateway/model/CommonRequestParams.java
+++ b/src/main/java/org/semantics/apigateway/model/CommonRequestParams.java
@@ -27,6 +27,10 @@ public class CommonRequestParams {
     @QueryParam("targetDbSchema")
     @Parameter(name = "targetDbSchema", in = ParameterIn.QUERY, description = "Transform the response result to a specific schema")
     private TargetDbSchema targetDbSchema;
+    
+    @QueryParam("collectionId")
+    @Parameter(name = "collectionId", in = ParameterIn.QUERY, description = "Restrict the response to artefacts contained in a given collection")
+    private String collectionId;
 
     @QueryParam("showResponseConfiguration")
     private boolean showResponseConfiguration = false;

--- a/src/main/java/org/semantics/apigateway/service/AbstractEndpointService.java
+++ b/src/main/java/org/semantics/apigateway/service/AbstractEndpointService.java
@@ -1,11 +1,13 @@
 package org.semantics.apigateway.service;
 
+import org.semantics.apigateway.collections.CollectionService;
 import org.semantics.apigateway.collections.models.CollectionResource;
 import org.semantics.apigateway.collections.models.TerminologyCollection;
 import org.semantics.apigateway.config.DatabaseConfig;
 import org.semantics.apigateway.model.CommonRequestParams;
 import org.semantics.apigateway.model.TargetDbSchema;
 import org.semantics.apigateway.model.responses.*;
+import org.semantics.apigateway.model.user.User;
 import org.semantics.apigateway.service.configuration.ConfigurationLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,17 +34,19 @@ public abstract class AbstractEndpointService {
     private final CacheManager cacheManager;
     private final JsonLdTransform jsonLdTransform;
     protected final ResponseAggregatorService aggregatorTransformer;
+    protected final CollectionService collectionService;
     private final List<DatabaseConfig> ontologyConfigs;
 
     protected static final Logger logger = LoggerFactory.getLogger(AbstractEndpointService.class);
 
-    public AbstractEndpointService(ConfigurationLoader configurationLoader, CacheManager cacheManager, JsonLdTransform jsonLdTransform, ResponseTransformerService responseTransformerService, Class<? extends AggregatedResourceBody> clazz) {
+    public AbstractEndpointService(ConfigurationLoader configurationLoader, CacheManager cacheManager, JsonLdTransform jsonLdTransform, ResponseTransformerService responseTransformerService, CollectionService collectionService, Class<? extends AggregatedResourceBody> clazz) {
         this.configurationLoader = configurationLoader;
         this.ontologyConfigs = configurationLoader.getDatabaseConfigs();
         this.jsonLdTransform = jsonLdTransform;
         this.responseTransformerService = responseTransformerService;
         this.cacheManager = cacheManager;
         this.aggregatorTransformer = new ResponseAggregatorService(clazz);
+        this.collectionService = collectionService;
     }
 
     public ApiAccessor getAccessor() {
@@ -406,11 +410,12 @@ public abstract class AbstractEndpointService {
 
 
     protected Object paginatedList(String acronym, String uri, String endpoint, CommonRequestParams params,
-                                   Integer page, ApiAccessor accessor) {
+                                   Integer page, ApiAccessor accessor, User currentUser) {
 
         String database = params.getDatabase();
         TargetDbSchema targetDbSchema = params.getTargetDbSchema();
         accessor = initAccessor(database, endpoint, accessor);
+        accessor = applyCollection(accessor, collectionService.getCurrentUserCollection(params.getCollectionId(), currentUser), endpoint);
         List<String> ids = getRequestIds(accessor, acronym, uri);
         ids.add(page.toString());
 
@@ -423,14 +428,15 @@ public abstract class AbstractEndpointService {
     }
 
     protected Object paginatedList(String id, String endpoint, CommonRequestParams params, Integer
-            page, ApiAccessor accessor) {
-        return paginatedList(id, null, endpoint, params, page, accessor);
+            page, ApiAccessor accessor,  User currentUser) {
+        return paginatedList(id, null, endpoint, params, page, accessor, currentUser);
     }
 
 
-    protected CompletableFuture<AggregatedApiResponse> findAll(String acronym, String uri, String endpoint, CommonRequestParams params, ApiAccessor accessor) {
+    protected CompletableFuture<AggregatedApiResponse> findAll(String acronym, String uri, String endpoint, CommonRequestParams params, ApiAccessor accessor, User currentUser) {
         String database = params.getDatabase();
         accessor = initAccessor(database, endpoint, accessor);
+        accessor = applyCollection(accessor, collectionService.getCurrentUserCollection(params.getCollectionId(), currentUser), endpoint);
         List<String> ids = getRequestIds(accessor, acronym, uri);
 
         return accessor.get(params.getTimeout(), ids.toArray(new String[0]))
@@ -441,8 +447,8 @@ public abstract class AbstractEndpointService {
     }
 
     protected CompletableFuture<AggregatedApiResponse> findAll(String id, String endpoint, CommonRequestParams params, ApiAccessor
-            accessor) {
-        return findAll(id, null, endpoint, params, accessor);
+            accessor,  User currentUser) {
+        return findAll(id, null, endpoint, params, accessor,  currentUser);
     }
 
     private List<String> getRequestIds(ApiAccessor accessor, String acronym, String uri) {
@@ -457,10 +463,11 @@ public abstract class AbstractEndpointService {
     }
 
     protected AggregatedApiResponse findUri(String id, String uri, String endpoint, CommonRequestParams params, ApiAccessor
-            accessor) {
+            accessor,  User currentUser) {
         String database = params.getDatabase();
         TargetDbSchema targetDbSchema = params.getTargetDbSchema();
         accessor = initAccessor(database, endpoint, accessor);
+        accessor = applyCollection(accessor, collectionService.getCurrentUserCollection(params.getCollectionId(), currentUser), endpoint);
         List<String> ids = getRequestIds(accessor, id, uri);
         try {
             return accessor.get(params.getTimeout(), ids.toArray(new String[0]))

--- a/src/test/java/org/semantics/apigateway/ArtefactDataServiceTest.java
+++ b/src/test/java/org/semantics/apigateway/ArtefactDataServiceTest.java
@@ -32,36 +32,36 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
         mockApiAccessor("artefact_term", artefactsService.getAccessor());
         CommonRequestParams params = new CommonRequestParams();
         params.setDatabase("skosmos");
-        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefactTerm("AGROVOC", "http://aims.fao.org/aos/agrovoc/c_330834", params, apiAccessor);
+        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefactTerm("AGROVOC", "http://aims.fao.org/aos/agrovoc/c_330834", params, apiAccessor, null);
         assertMapEquality(response, createSkosmosAgrovocTerm());
 
         params = new CommonRequestParams();
         params.setDatabase("ontoportal");
-        response = (AggregatedApiResponse) artefactsService.getArtefactTerm("AGROVOC", "http://aims.fao.org/aos/agrovoc/c_330834", params, apiAccessor);
+        response = (AggregatedApiResponse) artefactsService.getArtefactTerm("AGROVOC", "http://aims.fao.org/aos/agrovoc/c_330834", params, apiAccessor, null);
         assertMapEquality(response, createOntoPortalAgrovocTermFixture());
 
         params = new CommonRequestParams();
         params.setDatabase("ols2");
-        response = (AggregatedApiResponse) artefactsService.getArtefactTerm("ncbitaxon", "http://purl.obolibrary.org/obo/NCBITaxon_2", params, apiAccessor);
+        response = (AggregatedApiResponse) artefactsService.getArtefactTerm("ncbitaxon", "http://purl.obolibrary.org/obo/NCBITaxon_2", params, apiAccessor, null);
         assertMapEquality(response, createOls2NCBITaxonFixture());
 
         params = new CommonRequestParams();
         params.setDatabase("ols");
-        response = (AggregatedApiResponse) artefactsService.getArtefactTerm("ncbitaxon", "http://purl.obolibrary.org/obo/NCBITaxon_2", params, apiAccessor);
+        response = (AggregatedApiResponse) artefactsService.getArtefactTerm("ncbitaxon", "http://purl.obolibrary.org/obo/NCBITaxon_2", params, apiAccessor, null);
         assertMapEquality(response, createNCBITaxonFixture());
 
         params = new CommonRequestParams();
         params.setDatabase("gnd");
-        response = (AggregatedApiResponse) artefactsService.getArtefactTerm("gnd", "4074335-4", params, apiAccessor);
+        response = (AggregatedApiResponse) artefactsService.getArtefactTerm("gnd", "4074335-4", params, apiAccessor, null);
         assertMapEquality(response, createGndTermFixture());
             params = new CommonRequestParams();
 
         params.setDatabase("jskos");
-        response = (AggregatedApiResponse) artefactsService.getArtefactTerm("test", "http://superdatensatz.gbv.de/abc", params, apiAccessor);
+        response = (AggregatedApiResponse) artefactsService.getArtefactTerm("test", "http://superdatensatz.gbv.de/abc", params, apiAccessor, null);
         assertMapEquality(response, createdDanteTermFixture());
 
         params.setDatabase("jskos2");
-        response = (AggregatedApiResponse) artefactsService.getArtefactTerm("DDC", "http://dewey.info/class/612.112/e23/", params, apiAccessor);
+        response = (AggregatedApiResponse) artefactsService.getArtefactTerm("DDC", "http://dewey.info/class/612.112/e23/", params, apiAccessor, null);
         assertMapEquality(response, createColiConcTermFixture());
     }
 
@@ -71,25 +71,25 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
 
         CommonRequestParams params = new CommonRequestParams();
         params.setDatabase("ontoportal");
-        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefactProperty("AGROVOC", "http://purl.org/dc/terms/abstract", params, apiAccessor);
+        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefactProperty("AGROVOC", "http://purl.org/dc/terms/abstract", params, apiAccessor, null);
         assertMapEquality(response, createOntoPortalAgrovocPropertyFixture());
 
 
         params = new CommonRequestParams();
         params.setDatabase("ols");
-        response = (AggregatedApiResponse) artefactsService.getArtefactProperty("NCBITAXON", "http://purl.obolibrary.org/obo/ncbitaxon#has_rank", params, apiAccessor);
+        response = (AggregatedApiResponse) artefactsService.getArtefactProperty("NCBITAXON", "http://purl.obolibrary.org/obo/ncbitaxon#has_rank", params, apiAccessor, null);
         assertMapEquality(response, createOlsNCBITaxonPropertyFixture());
 
         params = new CommonRequestParams();
         params.setDatabase("ols2");
-        response = (AggregatedApiResponse) artefactsService.getArtefactProperty("NCBITAXON", "http://purl.obolibrary.org/obo/ncbitaxon#has_rank", params, apiAccessor);
+        response = (AggregatedApiResponse) artefactsService.getArtefactProperty("NCBITAXON", "http://purl.obolibrary.org/obo/ncbitaxon#has_rank", params, apiAccessor, null);
         assertMapEquality(response, createOls2NCBITaxonPropertyFixture());
     }
 
     @Test
     public void testGetCollection() {
         mockApiAccessor("artefact_collection", artefactsService.getAccessor());
-        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefactCollection("INRAETHES", "http://opendata.inrae.fr/thesaurusINRAE/gr_6c79e7c5", new CommonRequestParams(), apiAccessor);
+        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefactCollection("INRAETHES", "http://opendata.inrae.fr/thesaurusINRAE/gr_6c79e7c5", new CommonRequestParams(), apiAccessor, null);
         assertMapEquality(response, createOntoPortalINRAEThesCollectionFixture());
     }
 
@@ -98,24 +98,24 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
         mockApiAccessor("artefact_individual", artefactsService.getAccessor());
         CommonRequestParams params = new CommonRequestParams();
         params.setDatabase("ols2");
-        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefactIndividual("FOODON", "http://purl.obolibrary.org/obo/GAZ_00000464", new CommonRequestParams(), apiAccessor);
+        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefactIndividual("FOODON", "http://purl.obolibrary.org/obo/GAZ_00000464", new CommonRequestParams(), apiAccessor, null);
         assertMapEquality(response, createOls2FoodOnInstanceFixture());
 
         params = new CommonRequestParams();
         params.setDatabase("ontoportal");
-        response = (AggregatedApiResponse) artefactsService.getArtefactIndividual("FOODON", "http://purl.obolibrary.org/obo/GAZ_00000464", params, apiAccessor);
+        response = (AggregatedApiResponse) artefactsService.getArtefactIndividual("FOODON", "http://purl.obolibrary.org/obo/GAZ_00000464", params, apiAccessor, null);
         assertMapEquality(response, createOntoPortalFoodOnInstanceFixture());
 
         params = new CommonRequestParams();
         params.setDatabase("ols");
-        response = (AggregatedApiResponse) artefactsService.getArtefactIndividual("FOODON", "http://purl.obolibrary.org/obo/GAZ_00000464", params, apiAccessor);
+        response = (AggregatedApiResponse) artefactsService.getArtefactIndividual("FOODON", "http://purl.obolibrary.org/obo/GAZ_00000464", params, apiAccessor, null);
         assertMapEquality(response, createOlsFoodOnInstanceFixture());
     }
 
     @Test
     public void testGetScheme() {
         mockApiAccessor("artefact_scheme", artefactsService.getAccessor());
-        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefactScheme("INRAETHES", "http://opendata.inrae.fr/thesaurusINRAE/mt_50", new CommonRequestParams(), apiAccessor);
+        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefactScheme("INRAETHES", "http://opendata.inrae.fr/thesaurusINRAE/mt_50", new CommonRequestParams(), apiAccessor, null);
         assertMapEquality(response, createOntoPortalInraeScheme());
     }
 

--- a/src/test/java/org/semantics/apigateway/ArtefactServiceTest.java
+++ b/src/test/java/org/semantics/apigateway/ArtefactServiceTest.java
@@ -29,7 +29,7 @@ public class ArtefactServiceTest extends ApplicationTestAbstract {
     public void testGetArtefacts(){
         CommonRequestParams commonRequestParams = new CommonRequestParams();
         commonRequestParams.setDatabase("ontoportal");
-        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefact("AGROVOC", commonRequestParams, apiAccessor);
+        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefact("AGROVOC", commonRequestParams, apiAccessor, null);
         assertMapEquality(response, createOntoportalAgrovocFixture());
     }
 
@@ -38,7 +38,7 @@ public class ArtefactServiceTest extends ApplicationTestAbstract {
     public void testGetArtefactsSkosmos(){
         CommonRequestParams commonRequestParams = new CommonRequestParams();
         commonRequestParams.setDatabase("skosmos");
-        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefact("AGROVOC", commonRequestParams, apiAccessor);
+        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefact("AGROVOC", commonRequestParams, apiAccessor, null);
         assertMapEquality(response, createSkosmosAgrovocFixture());
     }
 
@@ -46,7 +46,7 @@ public class ArtefactServiceTest extends ApplicationTestAbstract {
     public void testGetArtefactsOls() {
         CommonRequestParams commonRequestParams = new CommonRequestParams();
         commonRequestParams.setDatabase("ols");
-        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefact("AGROVOC", commonRequestParams, apiAccessor);
+        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefact("AGROVOC", commonRequestParams, apiAccessor, null);
         assertMapEquality(response, createOlsAgrovocFixture());
     }
 
@@ -54,7 +54,7 @@ public class ArtefactServiceTest extends ApplicationTestAbstract {
     public void testGetArtefactGND() {
         CommonRequestParams commonRequestParams = new CommonRequestParams();
         commonRequestParams.setDatabase("gnd");
-        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefact("gnd", commonRequestParams, apiAccessor);
+        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefact("gnd", commonRequestParams, apiAccessor, null);
         assertMapEquality(response, createGndFixture());
     }
 
@@ -63,7 +63,7 @@ public class ArtefactServiceTest extends ApplicationTestAbstract {
     public void testGetArtefactJSkos() {
         CommonRequestParams commonRequestParams = new CommonRequestParams();
         commonRequestParams.setDatabase("jskos");
-        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefact("gender", commonRequestParams, apiAccessor);
+        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefact("gender", commonRequestParams, apiAccessor, null);
         assertMapEquality(response, createDanteFixture());
     }
 
@@ -72,7 +72,7 @@ public class ArtefactServiceTest extends ApplicationTestAbstract {
     public void testGetArtefactJSkos2() {
         CommonRequestParams commonRequestParams = new CommonRequestParams();
         commonRequestParams.setDatabase("jskos2");
-        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefact("EuroVoc", commonRequestParams, apiAccessor);
+        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefact("EuroVoc", commonRequestParams, apiAccessor, null);
         assertMapEquality(response, createColiConc());
     }
 }

--- a/src/test/java/org/semantics/apigateway/ArtefactsServiceTest.java
+++ b/src/test/java/org/semantics/apigateway/ArtefactsServiceTest.java
@@ -33,7 +33,7 @@ public class ArtefactsServiceTest extends ApplicationTestAbstract {
 
     @Test
     public void testGetAllArtefacts() {
-        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefacts(new CommonRequestParams(), null, null, apiAccessor);
+        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefacts(new CommonRequestParams(), null, apiAccessor);
         int index;
         int size = 1256;
         List<Map<String, Object>> responseList = response.getCollection();

--- a/src/test/java/org/semantics/apigateway/CommonRequestParamsTest.java
+++ b/src/test/java/org/semantics/apigateway/CommonRequestParamsTest.java
@@ -35,7 +35,7 @@ public class CommonRequestParamsTest extends ApplicationTestAbstract {
     public void testGetAllArtefactsWithDisplay() {
         CommonRequestParams params = new CommonRequestParams();
         params.setDisplay("short_form,backend_type,descriptions,synonyms,label");
-        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefacts(params, null, null, apiAccessor);
+        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefacts(params, null, apiAccessor);
         int index;
         List<Map<String, Object>> responseList = response.getCollection();
 
@@ -54,7 +54,7 @@ public class CommonRequestParamsTest extends ApplicationTestAbstract {
     public void testGetAllArtefactsWithNotDisplayEmptyValues() {
         CommonRequestParams params = new CommonRequestParams();
         params.setDisplayEmptyValues(false);
-        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefacts(params, null, null, apiAccessor);
+        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefacts(params, null, apiAccessor);
         int index;
         List<Map<String, Object>> responseList = response.getCollection();
 

--- a/src/test/java/org/semantics/apigateway/SearchServiceTest.java
+++ b/src/test/java/org/semantics/apigateway/SearchServiceTest.java
@@ -37,7 +37,7 @@ public class SearchServiceTest extends ApplicationTestAbstract {
     @Test
     public void testSearchAllDatabases() {
         CommonRequestParams commonRequestParams = new CommonRequestParams();
-        AggregatedApiResponse response = (AggregatedApiResponse) searchService.performSearch("plant", commonRequestParams, null, null, apiAccessor);
+        AggregatedApiResponse response = searchService.performSearch("plant", commonRequestParams, null, apiAccessor);
         int index;
         List<Map<String, Object>> responseList = response.getCollection();
 
@@ -66,7 +66,7 @@ public class SearchServiceTest extends ApplicationTestAbstract {
         CommonRequestParams commonRequestParams = new CommonRequestParams();
         commonRequestParams.setTargetDbSchema(TargetDbSchema.ols);
 
-        Map<String, Object> response = ((AggregatedApiResponse) searchService.performSearch("plant", commonRequestParams, null, null, apiAccessor)).getCollection().get(0);
+        Map<String, Object> response = searchService.performSearch("plant", commonRequestParams, null, apiAccessor).getCollection().get(0);
 
         assertThat(response.containsKey("response")).isTrue();
         assertThat(response.containsKey("responseHeader")).isTrue();
@@ -79,7 +79,7 @@ public class SearchServiceTest extends ApplicationTestAbstract {
     public void testSearchGnd() {
         CommonRequestParams commonRequestParams = new CommonRequestParams();
         commonRequestParams.setDatabase("gnd");
-        AggregatedApiResponse response = (AggregatedApiResponse) searchService.performSearch("London", commonRequestParams, null, null, apiAccessor);
+        AggregatedApiResponse response = searchService.performSearch("London", commonRequestParams, null, apiAccessor);
         assertMapEquality(response, createGndLondonFixture(), 10);
     }
 


### PR DESCRIPTION
This PR fixes the missing use of the collectionId parameter in some controller methods.
It moves the parameter into the CommonRequestParameters class, making it available everywhere.