### PR TITLE
Add query parameter for filtering out artefacts without a proper URi

### DIFF
--- a/src/main/java/org/semantics/apigateway/artefacts/metadata/ArtefactsService.java
+++ b/src/main/java/org/semantics/apigateway/artefacts/metadata/ArtefactsService.java
@@ -33,7 +33,6 @@ public class ArtefactsService extends AbstractEndpointService {
             return
                     findAllArtefacts(params, currentUser, accessor)
                             .thenApply(data -> transformJsonLd(data, params))
-                            .thenApply(data -> filterOutArtefactsWithoutProperIri(data, params))
                             .thenApply(data -> transformForTargetDbSchema(data, params.getTargetDbSchema(), endpoint)).get();
         } catch (InterruptedException | ExecutionException e) {
             logger.error(e.getMessage(), e);
@@ -43,7 +42,8 @@ public class ArtefactsService extends AbstractEndpointService {
 
 
     public Object getArtefact(String id, CommonRequestParams params, ApiAccessor accessor, User currentUser) {
-        return findUri(id, null, "resource_details", params, accessor, currentUser);
+        AggregatedApiResponse result = findUri(id, null, "resource_details", params, accessor, currentUser);
+        return result == null ? null : filterOutArtefactsWithoutProperIri(result, params);
     }
 
 
@@ -82,8 +82,8 @@ public class ArtefactsService extends AbstractEndpointService {
     private AggregatedApiResponse filterOutArtefactsWithoutProperIri(AggregatedApiResponse data, CommonRequestParams params) {
         if (params.isOmitArtefactsWithoutIri()) {
             data.setCollection(data.getCollection().stream().filter(result ->
-                    result.get("iri").toString().startsWith("https://") ||
-                            result.get("iri").toString().startsWith("http://")
+                    result.get("@id").toString().startsWith("https://") ||
+                            result.get("@id").toString().startsWith("http://")
             ).toList());
         }
         return data;
@@ -100,6 +100,7 @@ public class ArtefactsService extends AbstractEndpointService {
         return accessor.get(params.getTimeout())
                 .thenApply(data -> this.transformApiResponses(data, endpoint))
                 .thenApply(transformedData -> flattenResponseList(transformedData, params, collection))
+                .thenApply(data -> filterOutArtefactsWithoutProperIri(data, params))
                 .thenApply(data -> filterOutByCollection(collection, data));
     }
 }

--- a/src/main/java/org/semantics/apigateway/artefacts/metadata/ArtefactsService.java
+++ b/src/main/java/org/semantics/apigateway/artefacts/metadata/ArtefactsService.java
@@ -33,6 +33,7 @@ public class ArtefactsService extends AbstractEndpointService {
             return
                     findAllArtefacts(params, currentUser, accessor)
                             .thenApply(data -> transformJsonLd(data, params))
+                            .thenApply(data -> filterOutArtefactsWithoutProperIri(data, params))
                             .thenApply(data -> transformForTargetDbSchema(data, params.getTargetDbSchema(), endpoint)).get();
         } catch (InterruptedException | ExecutionException e) {
             logger.error(e.getMessage(), e);
@@ -75,6 +76,16 @@ public class ArtefactsService extends AbstractEndpointService {
 
         data.setCollection(filtered);
 
+        return data;
+    }
+    
+    private AggregatedApiResponse filterOutArtefactsWithoutProperIri(AggregatedApiResponse data, CommonRequestParams params) {
+        if (params.isOmitArtefactsWithoutIri()) {
+            data.setCollection(data.getCollection().stream().filter(result ->
+                    result.get("iri").toString().startsWith("https://") ||
+                            result.get("iri").toString().startsWith("http://")
+            ).toList());
+        }
         return data;
     }
 

--- a/src/main/java/org/semantics/apigateway/model/CommonRequestParams.java
+++ b/src/main/java/org/semantics/apigateway/model/CommonRequestParams.java
@@ -60,4 +60,7 @@ public class CommonRequestParams {
     @Parameter(name = "timeout", in = ParameterIn.QUERY, description = "Set a timeout (in milliseconds) for the operation")
     private long timeout = 60*1000;
     
+    @QueryParam("omitArtefactsWithoutIri")
+    @Parameter(name = "omitArtefactsWithoutIri", in = ParameterIn.QUERY, description = "If true, artefact queries will only return artefacts that have a proper IRI as their identifier (and filter out all that don't).")
+    private boolean omitArtefactsWithoutIri = false;
 }


### PR DESCRIPTION
This PR resolves #114.

The filtering of semantic artifacts that do not have a proper IRI as their identifier is activated by sending the query parameter `omitArtefactsWithoutIri=true` along with the request. The reason for making the filtering optional is backwards compatibility (OLS, for example, does not require an ontology ID to be a URI or IRI, and we still want to support that for legacy clients that use the OLS API and rely on this behavior).

The description of issue #114 includes ids of the form `file:/`... in the list of ids that should not be supported, although these are in fact valid URIs. As interoperability is the main motivation, the assumption is that what is actually meant was that ids should be URIs and they should be resolvable to physical addresses on the web. So the current solution provided by this PR only includes URIs starting with `https://` or `http://`. Supporting a wider range is of course possible.