### PR TITLE
Fix/150 collection permalinks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     implementation 'com.github.jsonld-java:jsonld-java:0.13.3'
     implementation 'org.springframework.boot:spring-boot-starter-integration'
     implementation 'jakarta.ws.rs:jakarta.ws.rs-api:3.1.0'
+    implementation 'com.io-informatics.oss:jackson-jsonld:0.1.1'
 
     // Swagger UI
     implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.6.0'

--- a/src/main/java/org/semantics/apigateway/collections/CollectionService.java
+++ b/src/main/java/org/semantics/apigateway/collections/CollectionService.java
@@ -11,10 +11,14 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 
 @Service
 public class CollectionService  {
+    
+    private static final Pattern permalinkPattern = Pattern.compile("https://w3id\\.org/ts4nfdi/collection/([a-f0-9-]+)");
 
     private final CollectionRepository collectionRepository;
     private final AuthService authService;
@@ -44,7 +48,13 @@ public class CollectionService  {
         if (collectionId == null || collectionId.isEmpty()) {
             return null;
         }
-
+        
+        // https://github.com/ts4nfdi/api-gateway/issues/150
+        Matcher matcher = permalinkPattern.matcher(collectionId);
+        if (matcher.matches()) {
+            collectionId = matcher.group(1);
+        }
+        
         Optional<TerminologyCollection> collection = this.getCollectionById(UUID.fromString(collectionId), user);
 
         if (collection.isPresent()) {
@@ -104,7 +114,6 @@ public class CollectionService  {
         this.collectionRepository.delete(collection);
     }
 
-
     private List<CollectionResource> createCollectionResources(List<ResourceDto> resources, TerminologyCollection collection) {
         List<CollectionResource> collectionResources = resources.stream().map(resource -> {
             CollectionResource collectionResource = new CollectionResource();
@@ -117,6 +126,7 @@ public class CollectionService  {
         }).toList();
         return  collectionResourceRepository.saveAll(collectionResources);
     }
+    
     private List<CollectionCollaborator> createCollectionCollaborators(List<CollectionCollaboratorDto> usernames, TerminologyCollection collection) {
         List<User> collaborators = userRepository.findByUsernameIn(usernames.stream().map(CollectionCollaboratorDto::username).toList());
         List<CollectionCollaborator> collectionCollaborators =  collaborators.stream().map(user -> {

--- a/src/main/java/org/semantics/apigateway/collections/CollectionsController.java
+++ b/src/main/java/org/semantics/apigateway/collections/CollectionsController.java
@@ -1,11 +1,8 @@
 package org.semantics.apigateway.collections;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import ioinformarics.oss.jackson.module.jsonld.JsonldModule;
 import lombok.AllArgsConstructor;
 import org.semantics.apigateway.collections.models.TerminologyCollection;
 import org.semantics.apigateway.collections.models.TerminologyCollectionDto;
@@ -29,16 +26,8 @@ public class CollectionsController {
     private final CollectionRepository collectionRepository;
     private final AuthService authService;
     
-    private static final ObjectMapper objectMapper;
-    
-    static {
-        objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new JsonldModule());
-        objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
-    }
-
-    @GetMapping("/")
-    public String allCollections() throws JsonProcessingException {
+    @GetMapping(value = "/", produces = CollectionsJsonLdMessageConverter.MEDIA_TYPE_APPLICATION_LD_JSON_VALUE)
+    public List<TerminologyCollectionDto> allCollections() {
         User user = authService.tryGetCurrentUser();
         List<TerminologyCollection> collections;
         if(user != null) {
@@ -46,7 +35,7 @@ public class CollectionsController {
         } else {
             collections = this.collectionRepository.findByIsPublicTrue();
         }
-        return objectMapper.writeValueAsString(collections.stream().map(TerminologyCollectionDto::toDto).toList());
+        return collections.stream().map(TerminologyCollectionDto::toDto).toList();
     }
 
 }

--- a/src/main/java/org/semantics/apigateway/collections/CollectionsController.java
+++ b/src/main/java/org/semantics/apigateway/collections/CollectionsController.java
@@ -1,7 +1,11 @@
 package org.semantics.apigateway.collections;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import ioinformarics.oss.jackson.module.jsonld.JsonldModule;
 import lombok.AllArgsConstructor;
 import org.semantics.apigateway.collections.models.TerminologyCollection;
 import org.semantics.apigateway.collections.models.TerminologyCollectionDto;
@@ -24,9 +28,17 @@ public class CollectionsController {
 
     private final CollectionRepository collectionRepository;
     private final AuthService authService;
+    
+    private static final ObjectMapper objectMapper;
+    
+    static {
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JsonldModule());
+        objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+    }
 
     @GetMapping("/")
-    public List<TerminologyCollectionDto> allCollections() {
+    public String allCollections() throws JsonProcessingException {
         User user = authService.tryGetCurrentUser();
         List<TerminologyCollection> collections;
         if(user != null) {
@@ -34,7 +46,7 @@ public class CollectionsController {
         } else {
             collections = this.collectionRepository.findByIsPublicTrue();
         }
-        return collections.stream().map(TerminologyCollectionDto::toDto).toList();
+        return objectMapper.writeValueAsString(collections.stream().map(TerminologyCollectionDto::toDto).toList());
     }
 
 }

--- a/src/main/java/org/semantics/apigateway/collections/CollectionsJsonLdMessageConverter.java
+++ b/src/main/java/org/semantics/apigateway/collections/CollectionsJsonLdMessageConverter.java
@@ -1,0 +1,63 @@
+package org.semantics.apigateway.collections;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import ioinformarics.oss.jackson.module.jsonld.JsonldModule;
+import org.semantics.apigateway.collections.models.TerminologyCollectionDto;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Collection;
+import java.util.List;
+
+@Component
+public class CollectionsJsonLdMessageConverter implements HttpMessageConverter<Collection<TerminologyCollectionDto>> {
+  
+  public static final String MEDIA_TYPE_APPLICATION_LD_JSON_VALUE = "application/ld+json";
+  public static final MediaType MEDIA_TYPE_APPLICATION_LD_JSON = MediaType.valueOf(MEDIA_TYPE_APPLICATION_LD_JSON_VALUE);
+  
+  private static final ObjectMapper customObjectMapper;
+  
+  static {
+    customObjectMapper = new ObjectMapper();
+    customObjectMapper.registerModule(new JsonldModule());
+    customObjectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+  }
+  
+  
+  @Override
+  public boolean canRead(Class<?> clazz, @Nullable MediaType mediaType) {
+    return false;
+  }
+  
+  @Override
+  public boolean canWrite(Class<?> clazz, @Nullable MediaType mediaType) {
+    return Collection.class.isAssignableFrom(clazz) && MEDIA_TYPE_APPLICATION_LD_JSON.equals(mediaType);
+  }
+  
+  @Override
+  public List<MediaType> getSupportedMediaTypes() {
+    return List.of(MEDIA_TYPE_APPLICATION_LD_JSON);
+  }
+  
+  @Override
+  public Collection<TerminologyCollectionDto> read(Class<? extends Collection<TerminologyCollectionDto>> clazz, HttpInputMessage inputMessage) throws IOException, HttpMessageNotReadableException {
+    return List.of();
+  }
+  
+  @Override
+  public void write(Collection<TerminologyCollectionDto> terminologyCollectionDtos, @Nullable MediaType contentType, HttpOutputMessage outputMessage) throws IOException, HttpMessageNotWritableException {
+    outputMessage.getHeaders().setContentType(MEDIA_TYPE_APPLICATION_LD_JSON);
+    try (OutputStream out = outputMessage.getBody()) {
+      customObjectMapper.writeValue(out, terminologyCollectionDtos);
+    }
+  }
+}

--- a/src/main/java/org/semantics/apigateway/collections/models/TerminologyCollectionDto.java
+++ b/src/main/java/org/semantics/apigateway/collections/models/TerminologyCollectionDto.java
@@ -1,53 +1,70 @@
 package org.semantics.apigateway.collections.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import ioinformarics.oss.jackson.module.jsonld.annotation.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.apache.jena.iri.IRIFactory;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
 
 @NoArgsConstructor
 @Data
+@JsonldResource
+@JsonldNamespace(name="collection", uri="https://w3id.org/ts4nfdi/collection/", applyToProperties = false)
+@JsonldType("collection:Collection")
 public class TerminologyCollectionDto {
+    
+    private static final IRIFactory iriFactory = IRIFactory.iriImplementation();
+    
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
-    UUID id;
+    @JsonldId
+    @JsonldProperty("http://base4nfdi.de/ts4nfdi/schema/iri")
+    String id;
+    
     @NotNull
+    @JsonldProperty("http://www.w3.org/2000/01/rdf-schema#label")
     String label;
+    
     @NotNull
+    @JsonldProperty("http://purl.org/dc/terms/creator")
     String creator;
+    
     @NotNull
+    @JsonldProperty("http://purl.org/dc/terms/description")
     String description;
+    
     @NotNull
-    @JsonProperty("isPublic")
+    @JsonProperty("collection:isPublic")
     boolean isPublic;
+    
+    @JsonldProperty("collection:collaborators")
     List<CollectionCollaboratorDto> collaborators = Collections.emptyList();
+    
+    
+    @JsonldProperty("collection:terminologies")
     List<ResourceDto> terminologies = Collections.emptyList();
 
 
     public static TerminologyCollectionDto toDto(TerminologyCollection x) {
         TerminologyCollectionDto dto = new TerminologyCollectionDto();
-        dto.setId(x.getId());
+        dto.setId(iriFactory.create("https://w3id.org/ts4nfdi/collection/" + x.getId()).toString());
         dto.setLabel(x.getLabel());
         dto.setDescription(x.getDescription());
         dto.setPublic(x.isPublic());
         dto.setCreator(x.getUser().getUsername());
-        dto.setCollaborators(x.getCollaborators().stream().map(c -> {
-            return new CollectionCollaboratorDto(
-                    c.getUser().getUsername(),
-                    c.getRole()
-            );
-        }).toList());
-        dto.setTerminologies(x.getTerminologies().stream().map(r -> {
-            return new ResourceDto(
-                    r.getUri(),
-                    r.getLabel(),
-                    r.getSource(),
-                    r.getType()
-            );
-        }).toList());
+        dto.setCollaborators(x.getCollaborators().stream().map(c -> new CollectionCollaboratorDto(
+                c.getUser().getUsername(),
+                c.getRole()
+        )).toList());
+        dto.setTerminologies(x.getTerminologies().stream().map(r -> new ResourceDto(
+                r.getUri(),
+                r.getLabel(),
+                r.getSource(),
+                r.getType()
+        )).toList());
         return dto;
     }
 }

--- a/src/main/java/org/semantics/apigateway/model/SemanticArtefact.java
+++ b/src/main/java/org/semantics/apigateway/model/SemanticArtefact.java
@@ -52,9 +52,6 @@ public class SemanticArtefact extends AggregatedResourceBody {
     //TODO use this instead of source in the future
     @ContextUri("schema")
     private List<String> includedInDataCatalog;
-    
-    @ContextUri("base4nfdi")
-    private String collectionIRI;
 
     @Override
     public String getTypeURI() {

--- a/src/main/java/org/semantics/apigateway/model/SemanticArtefact.java
+++ b/src/main/java/org/semantics/apigateway/model/SemanticArtefact.java
@@ -11,7 +11,9 @@ import java.util.List;
 @ContextBaseUri("dct")
 public class SemanticArtefact extends AggregatedResourceBody {
 
+    @ContextUri("owl")
     private String versionIRI;
+    
     private String accessRights;
     private String license;
     private String identifier;
@@ -26,8 +28,7 @@ public class SemanticArtefact extends AggregatedResourceBody {
     private List<String> publisher;
     private String coverage;
     private List<String> hasFormat;
-
-
+    
     @ContextUri("dcat")
     private List<String> keywords;
     @ContextUri("dcat")
@@ -51,6 +52,9 @@ public class SemanticArtefact extends AggregatedResourceBody {
     //TODO use this instead of source in the future
     @ContextUri("schema")
     private List<String> includedInDataCatalog;
+    
+    @ContextUri("base4nfdi")
+    private String collectionIRI;
 
     @Override
     public String getTypeURI() {

--- a/src/main/java/org/semantics/apigateway/service/AbstractEndpointService.java
+++ b/src/main/java/org/semantics/apigateway/service/AbstractEndpointService.java
@@ -287,21 +287,9 @@ public abstract class AbstractEndpointService {
             return data;
         }
 
-        return addCollectionIRI(filterOutByTerminologies(terminologiesCollection.getTerminologies(), data), terminologiesCollection);
+        return filterOutByTerminologies(terminologiesCollection.getTerminologies(), data);
     }
     
-    protected AggregatedApiResponse addCollectionIRI(AggregatedApiResponse response, TerminologyCollection terminologyCollection) {
-        response.getCollection().forEach(result -> {
-            if (terminologyCollection == null) {
-                result.remove("collectionIRI");
-                ((Map<String, Object>) result.get("@context")).remove("collectionIRI");
-            }
-            else
-                result.put("collectionIRI", "https://w3id.org/ts4nfdi/collection/" + terminologyCollection.getId());
-        });
-        return response;
-    }
-
     protected AggregatedApiResponse paginate(TransformedApiResponse response, CommonRequestParams
             commonRequestParams, int page) {
         AggregatedApiResponse aggregatedApiResponse = new AggregatedApiResponse();
@@ -489,7 +477,6 @@ public abstract class AbstractEndpointService {
                     .thenApply(data -> selectResultsByDatabase(data, database))
                     .thenApply(x -> singleResponse(x, params))
                     .thenApply(x -> transformJsonLd(x, params))
-                    .thenApply(x -> addCollectionIRI(x, terminologyCollection))
                     .thenApply(data -> transformForTargetDbSchema(data, targetDbSchema, endpoint, false))
                     .get();
         } catch (InterruptedException | ExecutionException e) {
@@ -506,10 +493,9 @@ public abstract class AbstractEndpointService {
 
         String id = ids.get(0);
 
-        return apiResponses.stream().map(x -> {
+        return apiResponses.stream().peek(x -> {
                     List<AggregatedResourceBody> filtered = x.getCollection().stream().filter(y -> y.getShortForm().equalsIgnoreCase(id) || y.getIri().equals(id)).toList();
                     x.setCollection(filtered);
-                    return x;
                 })
                 .filter(x -> !x.getCollection().isEmpty())
                 .toList();

--- a/src/main/java/org/semantics/apigateway/service/AbstractEndpointService.java
+++ b/src/main/java/org/semantics/apigateway/service/AbstractEndpointService.java
@@ -287,7 +287,17 @@ public abstract class AbstractEndpointService {
             return data;
         }
 
-        return filterOutByTerminologies(terminologiesCollection.getTerminologies(), data);
+        return addCollectionIRI(filterOutByTerminologies(terminologiesCollection.getTerminologies(), data), terminologiesCollection);
+    }
+    
+    protected AggregatedApiResponse addCollectionIRI(AggregatedApiResponse response, TerminologyCollection terminologyCollection) {
+        response.getCollection().forEach(result -> {
+            if (terminologyCollection == null)
+                result.remove("");
+            else
+                result.put("collectionIRI", "https://w3id.org/ts4nfdi/collection/" + terminologyCollection.getId());
+        });
+        return response;
     }
 
     protected AggregatedApiResponse paginate(TransformedApiResponse response, CommonRequestParams
@@ -467,7 +477,8 @@ public abstract class AbstractEndpointService {
         String database = params.getDatabase();
         TargetDbSchema targetDbSchema = params.getTargetDbSchema();
         accessor = initAccessor(database, endpoint, accessor);
-        accessor = applyCollection(accessor, collectionService.getCurrentUserCollection(params.getCollectionId(), currentUser), endpoint);
+        TerminologyCollection terminologyCollection = collectionService.getCurrentUserCollection(params.getCollectionId(), currentUser);
+        accessor = applyCollection(accessor, terminologyCollection, endpoint);
         List<String> ids = getRequestIds(accessor, id, uri);
         try {
             return accessor.get(params.getTimeout(), ids.toArray(new String[0]))
@@ -476,6 +487,7 @@ public abstract class AbstractEndpointService {
                     .thenApply(data -> selectResultsByDatabase(data, database))
                     .thenApply(x -> singleResponse(x, params))
                     .thenApply(x -> transformJsonLd(x, params))
+                    .thenApply(x -> addCollectionIRI(x, terminologyCollection))
                     .thenApply(data -> transformForTargetDbSchema(data, targetDbSchema, endpoint, false))
                     .get();
         } catch (InterruptedException | ExecutionException e) {

--- a/src/main/java/org/semantics/apigateway/service/AbstractEndpointService.java
+++ b/src/main/java/org/semantics/apigateway/service/AbstractEndpointService.java
@@ -293,7 +293,7 @@ public abstract class AbstractEndpointService {
     protected AggregatedApiResponse addCollectionIRI(AggregatedApiResponse response, TerminologyCollection terminologyCollection) {
         response.getCollection().forEach(result -> {
             if (terminologyCollection == null)
-                result.remove("");
+                result.remove("collectionIRI");
             else
                 result.put("collectionIRI", "https://w3id.org/ts4nfdi/collection/" + terminologyCollection.getId());
         });

--- a/src/main/java/org/semantics/apigateway/service/AbstractEndpointService.java
+++ b/src/main/java/org/semantics/apigateway/service/AbstractEndpointService.java
@@ -292,8 +292,10 @@ public abstract class AbstractEndpointService {
     
     protected AggregatedApiResponse addCollectionIRI(AggregatedApiResponse response, TerminologyCollection terminologyCollection) {
         response.getCollection().forEach(result -> {
-            if (terminologyCollection == null)
+            if (terminologyCollection == null) {
                 result.remove("collectionIRI");
+                ((Map<String, Object>) result.get("@context")).remove("collectionIRI");
+            }
             else
                 result.put("collectionIRI", "https://w3id.org/ts4nfdi/collection/" + terminologyCollection.getId());
         });


### PR DESCRIPTION
This PR resolves #150.

It adds the possibility to use the collection permalink as a query parameter (e.g. https://terminology.services.base4nfdi.de/api-gateway/artefacts?collectionId=https://w3id.org/ts4nfdi/collection/dc45621d-7e40-47ce-9616-4133f0b54edf) and  adds the collection permalink to the search result (if the collection uuid or permalink IRI has been used in the query).

The PR introduces the property `http://base4nfdi.de/ts4nfdi/schema/collectionIRI` because some artefacts have a value for `http://www.w3.org/2002/07/owl#versionIRI` already set (e.g., OLS uses the versionIRI property), which would then be overwritten.