### PR TITLE
Fix null values in artefact titles

### DIFF
--- a/src/frontend/app/home/browse/BrowseCard.tsx
+++ b/src/frontend/app/home/browse/BrowseCard.tsx
@@ -11,7 +11,7 @@ export const BrowseCard = ({artefact}: any) => {
 
     if (!artefact) return null;
 
-    const title = `${artefact.label} (${artefact.short_form})`
+    const title = artefact.label == null ? `${artefact.short_form}` : `${artefact.label} (${artefact.short_form})`
 
     return (
         <>

--- a/src/main/resources/backend_types/ols2.yml
+++ b/src/main/resources/backend_types/ols2.yml
@@ -6,7 +6,7 @@ pagination:
 
 models:
   artefact: &artefact
-    label: title|http://www.w3.org/2000/01/rdf-schema#label
+    label: label|title|http://www.w3.org/2000/01/rdf-schema#label
     iri: uri|iri
     ontology: ontologyId
     synonyms: label

--- a/src/main/resources/backend_types/ols2.yml
+++ b/src/main/resources/backend_types/ols2.yml
@@ -6,7 +6,7 @@ pagination:
 
 models:
   artefact: &artefact
-    label: label|title|http://www.w3.org/2000/01/rdf-schema#label
+    label: title|http://www.w3.org/2000/01/rdf-schema#label|label
     iri: uri|iri
     ontology: ontologyId
     synonyms: label


### PR DESCRIPTION
This PR fixes the appearance of null values in the artefact card grid. The existence of null values has two independent origins:

1. inconsistent use of keys for ontology titles in OLS
2. missing values for ontology titles (in OLS and possibly other TSs).

The first cause was approached by an additional mapping of OLS's label property.
The second issue was fixed by displaying just the short form if a label/title is missing.