### PR TITLE
Issue 180 - Configuration loading only works for endpoints with different base URLs

### DIFF
--- a/src/main/java/org/semantics/apigateway/config/DatabaseConfig.java
+++ b/src/main/java/org/semantics/apigateway/config/DatabaseConfig.java
@@ -3,10 +3,7 @@ package org.semantics.apigateway.config;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.semantics.apigateway.model.BackendType;
 import org.semantics.apigateway.model.Endpoints;
 import org.semantics.apigateway.model.RDFResource;
@@ -22,6 +19,7 @@ import java.util.Map;
 @NoArgsConstructor
 @AllArgsConstructor
 @Component
+@ToString(exclude = {"apiKey", "serviceConfig", "responseMappings"})
 public class DatabaseConfig {
     private String type;
     private String name;

--- a/src/main/java/org/semantics/apigateway/service/AbstractEndpointService.java
+++ b/src/main/java/org/semantics/apigateway/service/AbstractEndpointService.java
@@ -171,9 +171,7 @@ public abstract class AbstractEndpointService {
         ApiResponse results = entry.getValue();
         DatabaseConfig config = null;
         try {
-            URL baseUrl = new URL(url);
-            String baseUrlString = baseUrl.getProtocol() + "://" + baseUrl.getHost();
-            config = this.configurationLoader.getConfigByBaseUrl(baseUrlString);
+            config = this.configurationLoader.findBestMatchingConfig(url);
         } catch (Exception e) {
             logger.error("Error getting config for URL: {}", url, e);
         }

--- a/src/main/java/org/semantics/apigateway/service/configuration/ConfigurationLoader.java
+++ b/src/main/java/org/semantics/apigateway/service/configuration/ConfigurationLoader.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -35,6 +36,7 @@ public class ConfigurationLoader {
     private static final Logger logger = LoggerFactory.getLogger(ConfigurationLoader.class);
     private List<DatabaseConfig> databaseConfigs;
     private List<ServiceConfig> serviceConfigs;
+    private List<DatabaseConfig> databaseConfigsSorted;
 
     public  ConfigurationLoader(ResourceLoader resourceLoader, ConfigurableEnvironment environment) {
         this.resourceLoader = resourceLoader;
@@ -52,6 +54,13 @@ public class ConfigurationLoader {
                 ServicesConfig tempConfig = new ServicesConfig(serviceConfigs);
                 dbConfig.setServiceConfig(tempConfig.getService(dbConfig.getType()));
             }
+
+            this.databaseConfigsSorted = databaseConfigs.stream()
+                    .sorted(Comparator.comparingInt(
+                                    (DatabaseConfig c) -> c.getUrl().length())
+                            .reversed())
+                    .toList();
+
             databaseConfigs.forEach(config -> logger.info("Loaded config: {}", config));
         } catch (IOException e) {
             logger.error("Failed to load configurations", e);
@@ -140,6 +149,17 @@ public class ConfigurationLoader {
                 })
                 .findFirst()
                 .orElseThrow(() -> new RuntimeException("Config not found for URL: " + url));
+    }
+
+    public DatabaseConfig findBestMatchingConfig(String url) {
+
+        for (DatabaseConfig c : databaseConfigsSorted) {
+            if (url.startsWith(c.getUrl())) {
+                return c;
+            }
+        }
+
+        throw new RuntimeException("Config not found for URL: " + url);
     }
 
 }

--- a/src/main/resources/databases.json
+++ b/src/main/resources/databases.json
@@ -46,6 +46,11 @@
       "url": "https://semanticlookup.zbmed.de/ols/api"
     },
     {
+      "type": "ols2",
+      "name": "berd",
+      "url": "https://ts.berd-nfdi.de/ols4/api/v2"
+    },
+    {
       "type": "skosmos",
       "name": "agrovoc",
       "url": "https://agrovoc.fao.org/browse/rest/v1"


### PR DESCRIPTION
closes #180 

- Added a sorted configs list (with URLs sorted by size) to select the best matching URL.
- Added the ToString annotation to the configs class to make the logging readable.
- Added BERD@NFDI OLS4 V2 source