### PR TITLE
Add provider info to OLS and OLS2 transformer output

### DIFF
--- a/src/main/java/org/semantics/apigateway/api/OlsTransformer.java
+++ b/src/main/java/org/semantics/apigateway/api/OlsTransformer.java
@@ -44,6 +44,14 @@ public class OlsTransformer implements DatabaseTransformer {
             }
         }
         
+        Map<String, Object> provider = new HashMap<>();
+        if (item.get("backend_type") != null) provider.put("provider_type", item.get("backend_type"));
+        if (item.get("source") != null) provider.put("provider_api", item.get("source"));
+        if (item.get("source_name") != null) provider.put("provider_name", item.get("source_name"));
+        if (!provider.isEmpty()) {
+            transformedItem.put("provider", provider);
+        }
+
         transformedItem.put("URI", item.get("iri"));
         transformedItem.put("@type", new SemanticArtefact().getTypeURI());
         return transformedItem;

--- a/src/main/java/org/semantics/apigateway/api/OlsV2Transformer.java
+++ b/src/main/java/org/semantics/apigateway/api/OlsV2Transformer.java
@@ -40,6 +40,14 @@ public class OlsV2Transformer implements DatabaseTransformer {
             }
         });
 
+        Map<String, Object> provider = new HashMap<>();
+        if (item.get("backend_type") != null) provider.put("provider_type", item.get("backend_type"));
+        if (item.get("source") != null) provider.put("provider_api", item.get("source"));
+        if (item.get("source_name") != null) provider.put("provider_name", item.get("source_name"));
+        if (!provider.isEmpty()) {
+            transformedItem.put("provider", provider);
+        }
+
         transformedItem.put("URI", item.get("iri"));
         transformedItem.put("@type", new SemanticArtefact().getTypeURI());
         return transformedItem;
@@ -60,7 +68,7 @@ public class OlsV2Transformer implements DatabaseTransformer {
         
         return transformedResults.isEmpty() ? null : transformedResults.get(0);
     }
-    
+
     private Object getNestedValue(Map<String, Object> item, String key) {
         String[] path = key.split("->");
         Object current = item;

--- a/src/test/java/org/semantics/apigateway/api/ProviderTransformTest.java
+++ b/src/test/java/org/semantics/apigateway/api/ProviderTransformTest.java
@@ -1,0 +1,94 @@
+package org.semantics.apigateway.api;
+
+import org.junit.jupiter.api.Test;
+import org.semantics.apigateway.config.ResponseMapping;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Covers the aggregator-added provenance fields (backend_type, source, source_name) being
+ * carried over into a nested "provider" object by the OLS transformers.
+ */
+public class ProviderTransformTest {
+
+    private ResponseMapping mapping() {
+        ResponseMapping mapping = new ResponseMapping();
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("label", "label");
+        mapping.setMappedClassAttributes(attributes);
+        mapping.setKey("elements");
+        return mapping;
+    }
+
+    private Map<String, Object> itemWithProvenance() {
+        Map<String, Object> item = new HashMap<>();
+        item.put("iri", "http://example.org/term/1");
+        item.put("label", "Example");
+        item.put("backend_type", "ols2");
+        item.put("source", "https://www.ebi.ac.uk/ols4/api/v2");
+        item.put("source_name", "ebi");
+        return item;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> assertProvider(Map<String, Object> transformed) {
+        assertThat(transformed).containsKey("provider");
+        Map<String, Object> provider = (Map<String, Object>) transformed.get("provider");
+        assertThat(provider)
+                .containsEntry("provider_type", "ols2")
+                .containsEntry("provider_api", "https://www.ebi.ac.uk/ols4/api/v2")
+                .containsEntry("provider_name", "ebi");
+        return provider;
+    }
+
+    @Test
+    public void olsV2TransformerNestsProvenanceUnderProvider() {
+        Map<String, Object> transformed = new OlsV2Transformer().transformItem(itemWithProvenance(), mapping());
+        assertProvider(transformed);
+    }
+
+    @Test
+    public void olsTransformerNestsProvenanceUnderProvider() {
+        Map<String, Object> transformed = new OlsTransformer().transformItem(itemWithProvenance(), mapping());
+        assertProvider(transformed);
+    }
+
+    @Test
+    public void olsV2TransformerOmitsProviderWhenNoProvenance() {
+        Map<String, Object> item = new HashMap<>();
+        item.put("iri", "http://example.org/term/1");
+        item.put("label", "Example");
+
+        Map<String, Object> transformed = new OlsV2Transformer().transformItem(item, mapping());
+        assertThat(transformed).doesNotContainKey("provider");
+    }
+
+    @Test
+    public void olsTransformerOmitsProviderWhenNoProvenance() {
+        Map<String, Object> item = new HashMap<>();
+        item.put("iri", "http://example.org/term/1");
+        item.put("label", "Example");
+
+        Map<String, Object> transformed = new OlsTransformer().transformItem(item, mapping());
+        assertThat(transformed).doesNotContainKey("provider");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void olsV2TransformerIncludesOnlyPresentProvenanceFields() {
+        Map<String, Object> item = new HashMap<>();
+        item.put("iri", "http://example.org/term/1");
+        item.put("label", "Example");
+        item.put("backend_type", "ols2");
+
+        Map<String, Object> transformed = new OlsV2Transformer().transformItem(item, mapping());
+        Map<String, Object> provider = (Map<String, Object>) transformed.get("provider");
+        assertThat(provider)
+                .containsEntry("provider_type", "ols2")
+                .doesNotContainKey("provider_api")
+                .doesNotContainKey("provider_name");
+    }
+}


### PR DESCRIPTION
The OLS controllers force a target-schema transform (ols/ols2) that rebuilds each item from the response mapping via OlsTransformer and OlsV2Transformer.transformItem. This dropped the aggregator-added provenance fields (backend_type, source, source_name), which are set after mapping in AggregatedResourceBody.setDefaultValues and so are absent from these endpoints' responses while present everywhere else.

Carry them over into a nested "provider" object:
  provider_type <- backend_type
  provider_api  <- source
  provider_name <- source_name

Each field is added only when present, and "provider" is only attached when at least one is set.

closes #188