### PR TITLE
Fix/182 named query params

### DIFF
--- a/src/main/java/org/semantics/apigateway/artefacts/search/SearchService.java
+++ b/src/main/java/org/semantics/apigateway/artefacts/search/SearchService.java
@@ -8,10 +8,7 @@ import org.semantics.apigateway.model.RDFResource;
 import org.semantics.apigateway.model.TargetDbSchema;
 import org.semantics.apigateway.model.responses.AggregatedApiResponse;
 import org.semantics.apigateway.model.user.User;
-import org.semantics.apigateway.service.AbstractEndpointService;
-import org.semantics.apigateway.service.ApiAccessor;
-import org.semantics.apigateway.service.JsonLdTransform;
-import org.semantics.apigateway.service.ResponseTransformerService;
+import org.semantics.apigateway.service.*;
 import org.semantics.apigateway.service.configuration.ConfigurationLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,7 +59,7 @@ public class SearchService extends AbstractEndpointService {
         accessor = applyCollection(accessor, collection, endpoint);
         
         try {
-            return accessor.get(params.getTimeout(), query)
+            return accessor.get(params.getTimeout(), Map.of(RequestParameter.query, query))
                     .thenApply(data -> this.transformApiResponses(data, endpoint))
                     .thenApply(transformedData -> flattenResponseList(transformedData, params, collection))
                     .thenApply(data -> filterOutByCollection(collection, data))
@@ -77,16 +74,16 @@ public class SearchService extends AbstractEndpointService {
     }
     
     public AggregatedApiResponse suggestConcepts(
-            String id,
+            String artifactId,
             String query,
             int offset,
             int size,
             CommonRequestParams params) {
-        return suggestConcepts(id, query, offset, size, params, null, null);
+        return suggestConcepts(artifactId, query, offset, size, params, null, null);
     }
     
     public AggregatedApiResponse suggestConcepts(
-            String id,
+            String artifactId,
             String query,
             int offset,
             int size,
@@ -102,8 +99,15 @@ public class SearchService extends AbstractEndpointService {
         
         // TODO add ontology parameter as soon as https://github.com/ts4nfdi/api-gateway/issues/123 has been resolved.
         
+        Map<RequestParameter, String> requestParameters = Map.of(
+                RequestParameter.artefact, artifactId,
+                RequestParameter.query, query,
+                RequestParameter.size, "" + size,
+                RequestParameter.offset, "" + offset
+        );
+        
         try {
-            return accessor.get(params.getTimeout(), query, "" + size, "" + offset)
+            return accessor.get(params.getTimeout(), requestParameters)
                     .thenApply(data -> this.transformApiResponses(data, endpoint))
                     .thenApply(transformedData -> flattenResponseList(transformedData, params, collection))
                     .thenApply(data -> filterOutByCollection(collection, data))

--- a/src/main/java/org/semantics/apigateway/artefacts/search/SearchService.java
+++ b/src/main/java/org/semantics/apigateway/artefacts/search/SearchService.java
@@ -16,6 +16,7 @@ import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -59,7 +60,7 @@ public class SearchService extends AbstractEndpointService {
         accessor = applyCollection(accessor, collection, endpoint);
         
         try {
-            return accessor.get(params.getTimeout(), Map.of(RequestParameter.query, query))
+            return accessor.get(params.getTimeout(), new HashMap<>(Map.of(RequestParameter.query, query)))
                     .thenApply(data -> this.transformApiResponses(data, endpoint))
                     .thenApply(transformedData -> flattenResponseList(transformedData, params, collection))
                     .thenApply(data -> filterOutByCollection(collection, data))
@@ -99,12 +100,12 @@ public class SearchService extends AbstractEndpointService {
         
         // TODO add ontology parameter as soon as https://github.com/ts4nfdi/api-gateway/issues/123 has been resolved.
         
-        Map<RequestParameter, String> requestParameters = Map.of(
+        Map<RequestParameter, String> requestParameters = new HashMap<>(Map.of(
                 RequestParameter.artefact, artifactId,
                 RequestParameter.query, query,
                 RequestParameter.size, "" + size,
                 RequestParameter.offset, "" + offset
-        );
+        ));
         
         try {
             return accessor.get(params.getTimeout(), requestParameters)

--- a/src/main/java/org/semantics/apigateway/artefacts/tree/ArtefactsDataTreeService.java
+++ b/src/main/java/org/semantics/apigateway/artefacts/tree/ArtefactsDataTreeService.java
@@ -31,20 +31,20 @@ public class ArtefactsDataTreeService extends AbstractEndpointService {
         super(configurationLoader, cacheManager, transform, responseTransformerService, collectionService, RDFResource.class);
     }
 
-    public Object getRoots(String acronym, CommonRequestParams params, ApiAccessor accessor, User currentUser) {
-        if (acronym == null || acronym.isEmpty()) {
+    public Object getRoots(String artefactId, CommonRequestParams params, ApiAccessor accessor, User currentUser) {
+        if (artefactId == null || artefactId.isEmpty()) {
             return new AggregatedApiResponse();
         }
         String endpoint = Endpoints.concepts_roots.toString();
         accessor = initAccessor(params.getDatabase(), endpoint, accessor);
-        return findAll(acronym, endpoint, params, accessor, currentUser).thenApply(x -> {
+        return findAll(artefactId, endpoint, params, accessor, currentUser).thenApply(x -> {
             x.setCollection(sortChildren(x.getCollection()));
             return x;
         });
     }
 
-    public Object getChildren(String acronym, String uri, CommonRequestParams params, Integer page, ApiAccessor accessor,  User currentUser) {
-        if (acronym == null || acronym.isEmpty() || uri == null || uri.isEmpty()) {
+    public Object getChildren(String artefactId, String resourceUri, CommonRequestParams params, Integer page, ApiAccessor accessor,  User currentUser) {
+        if (artefactId == null || artefactId.isEmpty() || resourceUri == null || resourceUri.isEmpty()) {
             return Collections.EMPTY_LIST;
         }
 
@@ -52,32 +52,32 @@ public class ArtefactsDataTreeService extends AbstractEndpointService {
         DatabaseConfig databaseConfig = configurationLoader.getConfigByName(params.getDatabase());
         accessor = initAccessor(params.getDatabase(), endpoint, accessor);
         if (databaseConfig.isOls2()) {
-            uri = URLEncoder.encode(URLEncoder.encode(uri)); // OLS2 requires URI double encoding
+            resourceUri = URLEncoder.encode(URLEncoder.encode(resourceUri)); // OLS2 requires URI double encoding
         }
-        return paginatedList(acronym, uri, endpoint, params, page, accessor,  currentUser);
+        return paginatedList(artefactId, resourceUri, endpoint, params, page, accessor,  currentUser);
     }
 
-    public Object getTree(String acronym, String uri, CommonRequestParams params, ApiAccessor accessor, User currentUser) {
-        if (acronym == null || acronym.isEmpty() || uri == null || uri.isEmpty()) {
+    public Object getTree(String artefactId, String resourceUri, CommonRequestParams params, ApiAccessor accessor, User currentUser) {
+        if (artefactId == null || artefactId.isEmpty() || resourceUri == null || resourceUri.isEmpty()) {
             return Collections.EMPTY_LIST;
         }
         String endpoint = Endpoints.concept_tree.toString();
         DatabaseConfig databaseConfig = configurationLoader.getConfigByName(params.getDatabase());
         accessor = initAccessor(params.getDatabase(), endpoint, accessor);
-        String finalUri = uri;
+        String finalUri = resourceUri;
         if (databaseConfig.isOls2()) {
-            finalUri = URLEncoder.encode(URLEncoder.encode(uri)); // OLS2 requires URI double encoding
+            finalUri = URLEncoder.encode(URLEncoder.encode(resourceUri)); // OLS2 requires URI double encoding
         }
 
-        return findAll(acronym, finalUri, endpoint, params, accessor, currentUser)
-                .thenApply(data -> databaseConfig.isOls() ? buildOlsTree(data, acronym, uri, params, currentUser) : data)
+        return findAll(artefactId, finalUri, endpoint, params, accessor, currentUser)
+                .thenApply(data -> databaseConfig.isOls() ? buildOlsTree(data, artefactId, resourceUri, params, currentUser) : data)
                 .thenApply(data -> databaseConfig.isOntoPortal() ? transformAllNestedChildren(data, databaseConfig, endpoint) : data);
     }
 
-    private AggregatedApiResponse buildOlsTree(AggregatedApiResponse data, String acronym, String uri, CommonRequestParams params, User currentUser) {
+    private AggregatedApiResponse buildOlsTree(AggregatedApiResponse data, String artefactId, String resourceUri, CommonRequestParams params, User currentUser) {
         List<Map<String, Object>> pathToRoot = data.getCollection();
         List<Map<String, Object>> cleanedPath = new ArrayList<>();
-        Map<String, Object> leafNode = findUri(acronym, uri, Endpoints.concept_details.toString(), params, null, currentUser).getCollection().get(0);
+        Map<String, Object> leafNode = findUri(artefactId, resourceUri, Endpoints.concept_details.toString(), params, null, currentUser).getCollection().get(0);
 
         for (Map<String, Object> child : pathToRoot) {
             if (child.get("iri").equals("http://www.w3.org/2002/07/owl#Thing")) {

--- a/src/main/java/org/semantics/apigateway/config/DatabaseConfig.java
+++ b/src/main/java/org/semantics/apigateway/config/DatabaseConfig.java
@@ -30,6 +30,7 @@ public class DatabaseConfig {
     private ServiceConfig serviceConfig;
     @JsonIgnore
     private final HashMap<String, ResponseMapping>  responseMappings = new HashMap<>();
+    @JsonIgnore
 
     // TODO The response mappings are constructed anew at each request-response cycle, although they should presumably remain unchanged throughout the application lifetime.
     public ResponseMapping getResponseMapping(String endpoint) {
@@ -94,7 +95,7 @@ public class DatabaseConfig {
     }
 
     public UrlConfig getUrlConfig(String endpoint) {
-        return new UrlConfig(getUrl(), getApiKey(), getEndpointConfig(endpoint).isCaseInsensitive(), serviceConfig.getPagination());
+        return new UrlConfig(getUrl(), getApiKey(), getEndpointConfig(endpoint).isCaseInsensitive(), serviceConfig.getPagination(), getEndpointConfig(endpoint).getParameters());
     }
 
     public String getSearchUrl() {

--- a/src/main/java/org/semantics/apigateway/config/EndpointConfig.java
+++ b/src/main/java/org/semantics/apigateway/config/EndpointConfig.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.semantics.apigateway.service.RequestParameter;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
@@ -17,5 +18,6 @@ import java.util.Map;
 public class EndpointConfig {
     private String path;
     private Map<String, String> responseMapping;
+    private Map<RequestParameter, EndpointParameterMapping> parameters;
     private boolean caseInsensitive = true;
 }

--- a/src/main/java/org/semantics/apigateway/config/EndpointConfig.java
+++ b/src/main/java/org/semantics/apigateway/config/EndpointConfig.java
@@ -18,6 +18,6 @@ import java.util.Map;
 public class EndpointConfig {
     private String path;
     private Map<String, String> responseMapping;
-    private Map<RequestParameter, EndpointParameterMapping> parameters;
+    private Map<RequestParameter, EndpointParameterMapping> parameters = Map.of();
     private boolean caseInsensitive = true;
 }

--- a/src/main/java/org/semantics/apigateway/config/EndpointParameterMapping.java
+++ b/src/main/java/org/semantics/apigateway/config/EndpointParameterMapping.java
@@ -1,0 +1,44 @@
+package org.semantics.apigateway.config;
+
+import lombok.*;
+
+import java.util.Arrays;
+import java.util.function.Function;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class EndpointParameterMapping {
+  
+  @AllArgsConstructor
+  public static class Parameter {
+    private String name;
+    private String value;
+  }
+  
+  @AllArgsConstructor
+  public enum Type {
+    path(x -> x.value),
+    string(x -> x.name + "=" + x.value),
+    stringAsterisk(x -> x.name + "*"),
+    integer(x -> x.name + "=" + x.value),
+    commaList(x -> x.name + "=" + String.join(",", x.value.split(","))),
+    pipeList(x -> x.name + "=" + String.join("|", x.value.split(","))),
+    jsonList(x -> x.name + "=" + "[" + String.join(",", x.value.split(",")) + "]"),
+    repeatedKeyList(x -> String.join("&", Arrays.stream(x.value.split(",")).sequential().map(s -> x.name + "=" + s).toList()));
+    
+    private Function<Parameter, String> serializer;
+    
+  }
+  
+  @NonNull
+  private Type type;
+  
+  private String name;
+  private boolean optional = false;
+  
+  public String serializeParameter(String value) {
+    return type.serializer.apply(new Parameter(name, value));
+  }
+  
+}

--- a/src/main/java/org/semantics/apigateway/service/AbstractEndpointService.java
+++ b/src/main/java/org/semantics/apigateway/service/AbstractEndpointService.java
@@ -15,7 +15,6 @@ import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
-import java.net.URL;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -407,17 +406,18 @@ public abstract class AbstractEndpointService {
     }
 
 
-    protected Object paginatedList(String acronym, String uri, String endpoint, CommonRequestParams params,
+    protected Object paginatedList(String artefactId, String resourceUri, String endpoint, CommonRequestParams params,
                                    Integer page, ApiAccessor accessor, User currentUser) {
 
         String database = params.getDatabase();
         TargetDbSchema targetDbSchema = params.getTargetDbSchema();
         accessor = initAccessor(database, endpoint, accessor);
         accessor = applyCollection(accessor, collectionService.getCurrentUserCollection(params.getCollectionId(), currentUser), endpoint);
-        List<String> ids = getRequestIds(accessor, acronym, uri);
-        ids.add(page.toString());
+        
+        Map<RequestParameter, String> apiParameters = getRequestIds(accessor, artefactId, resourceUri);
+        apiParameters.put(RequestParameter.page, "" + page);
 
-        return accessor.get(params.getTimeout(), ids.toArray(new String[0]))
+        return accessor.get(params.getTimeout(), apiParameters)
                 .thenApply(data -> this.transformApiResponses(data, endpoint, true))
                 .thenApply(data -> selectResultsByDatabase(data, database))
                 .thenApply(x -> paginate(x, params, page))
@@ -431,13 +431,13 @@ public abstract class AbstractEndpointService {
     }
 
 
-    protected CompletableFuture<AggregatedApiResponse> findAll(String acronym, String uri, String endpoint, CommonRequestParams params, ApiAccessor accessor, User currentUser) {
+    protected CompletableFuture<AggregatedApiResponse> findAll(String artefactId, String resourceUri, String endpoint, CommonRequestParams params, ApiAccessor accessor, User currentUser) {
         String database = params.getDatabase();
         accessor = initAccessor(database, endpoint, accessor);
         accessor = applyCollection(accessor, collectionService.getCurrentUserCollection(params.getCollectionId(), currentUser), endpoint);
-        List<String> ids = getRequestIds(accessor, acronym, uri);
+        Map<RequestParameter, String> requestParameters = getRequestIds(accessor, artefactId, resourceUri);
 
-        return accessor.get(params.getTimeout(), ids.toArray(new String[0]))
+        return accessor.get(params.getTimeout(), requestParameters)
                 .thenApply(data -> this.transformApiResponses(data, endpoint))
                 .thenApply(data -> selectResultsByDatabase(data, database))
                 .thenApply(data -> listResponse(data, params))
@@ -449,28 +449,31 @@ public abstract class AbstractEndpointService {
         return findAll(id, null, endpoint, params, accessor,  currentUser);
     }
 
-    private List<String> getRequestIds(ApiAccessor accessor, String acronym, String uri) {
-        List<String> ids = new ArrayList<>(List.of(acronym));
-        if (uri != null && !uri.isEmpty()) {
-            uri = URLDecoder.decode(uri, StandardCharsets.UTF_8);
-            String encodedUrl = URLEncoder.encode(uri, StandardCharsets.UTF_8);
-            ids.add(encodedUrl);
+    private Map<RequestParameter, String> getRequestIds(ApiAccessor accessor, String artefactId, String resourceUri) {
+        HashMap<RequestParameter, String> result = new HashMap<>();
+        result.put(RequestParameter.artefact, artefactId);
+        
+        if (resourceUri != null && !resourceUri.isEmpty()) {
+            resourceUri = URLDecoder.decode(resourceUri, StandardCharsets.UTF_8);
+            String encodedUrl = URLEncoder.encode(resourceUri, StandardCharsets.UTF_8);
+            result.put(RequestParameter.resourceUri, encodedUrl);
             accessor.setUnDecodeUrl(true);
         }
-        return ids;
+        
+        return result;
     }
 
-    protected AggregatedApiResponse findUri(String id, String uri, String endpoint, CommonRequestParams params, ApiAccessor
+    protected AggregatedApiResponse findUri(String id, String resourceUri, String endpoint, CommonRequestParams params, ApiAccessor
             accessor,  User currentUser) {
         String database = params.getDatabase();
         TargetDbSchema targetDbSchema = params.getTargetDbSchema();
         accessor = initAccessor(database, endpoint, accessor);
         accessor = applyCollection(accessor, collectionService.getCurrentUserCollection(params.getCollectionId(), currentUser), endpoint);
-        List<String> ids = getRequestIds(accessor, id, uri);
+        Map<RequestParameter, String> requestParameters = getRequestIds(accessor, id, resourceUri);
         try {
-            return accessor.get(params.getTimeout(), ids.toArray(new String[0]))
+            return accessor.get(params.getTimeout(), requestParameters)
                     .thenApply(data -> this.transformApiResponses(data, endpoint))
-                    .thenApply(x -> filterById(x, ids))
+                    .thenApply(x -> filterById(x, requestParameters))
                     .thenApply(data -> selectResultsByDatabase(data, database))
                     .thenApply(x -> singleResponse(x, params))
                     .thenApply(x -> transformJsonLd(x, params))
@@ -483,13 +486,14 @@ public abstract class AbstractEndpointService {
     }
 
     private List<TransformedApiResponse> filterById
-            (List<TransformedApiResponse> apiResponses, List<String> ids) {
-        if (ids == null || ids.size() > 1) {
+            (List<TransformedApiResponse> apiResponses, Map<RequestParameter, String> ids) {
+
+        String id = ids.get(RequestParameter.resourceUri);
+        
+        if (id == null) {
             return apiResponses;
         }
-
-        String id = ids.get(0);
-
+        
         return apiResponses.stream().map(x -> {
                     List<AggregatedResourceBody> filtered = x.getCollection().stream().filter(y -> y.getShortForm().equalsIgnoreCase(id) || y.getIri().equals(id)).toList();
                     x.setCollection(filtered);

--- a/src/main/java/org/semantics/apigateway/service/AbstractEndpointService.java
+++ b/src/main/java/org/semantics/apigateway/service/AbstractEndpointService.java
@@ -488,11 +488,15 @@ public abstract class AbstractEndpointService {
     private List<TransformedApiResponse> filterById
             (List<TransformedApiResponse> apiResponses, Map<RequestParameter, String> ids) {
 
-        String id = ids.get(RequestParameter.resourceUri);
+        String resourceUri = ids.get(RequestParameter.resourceUri);
+        String artefactId = ids.get(RequestParameter.artefact);
         
-        if (id == null) {
+        if (artefactId == null && resourceUri == null
+        || artefactId != null && resourceUri != null) {
             return apiResponses;
         }
+        
+        String id = artefactId == null ? resourceUri : artefactId;
         
         return apiResponses.stream().map(x -> {
                     List<AggregatedResourceBody> filtered = x.getCollection().stream().filter(y -> y.getShortForm().equalsIgnoreCase(id) || y.getIri().equals(id)).toList();

--- a/src/main/java/org/semantics/apigateway/service/ApiAccessor.java
+++ b/src/main/java/org/semantics/apigateway/service/ApiAccessor.java
@@ -153,7 +153,7 @@ public class ApiAccessor {
         boolean isCaseInsensitive = config.caseInSensitive();
         
         if(isCaseInsensitive && requestParameters.get(RequestParameter.artefact) != null)
-            requestParameters.put(RequestParameter.query, (requestParameters.get(RequestParameter.artefact)).toUpperCase());
+            requestParameters.put(RequestParameter.artefact, (requestParameters.get(RequestParameter.artefact)).toUpperCase());
         
         try {
             requestParameters.put(RequestParameter.page, "" + (Integer.parseInt(Optional.ofNullable(requestParameters.get(RequestParameter.page)).orElse("0")) + config.pagination().getFirst()));

--- a/src/main/java/org/semantics/apigateway/service/ApiAccessor.java
+++ b/src/main/java/org/semantics/apigateway/service/ApiAccessor.java
@@ -132,7 +132,13 @@ public class ApiAccessor {
                     out.put("collection", response.getBody());
                     result.setResponseBody(out);
                 } else {
-                    result.setResponseBody((Map<String, Object>) response.getBody());
+                    Map<String, Object> resultMap = (Map<String, Object>) response.getBody();
+                    if (resultMap.containsKey("error")) {
+                        logger.error("Backend returned an error message processing the request {}: {}", fullUrl, resultMap.get("error"));
+                    } else {
+                        result.setResponseBody(resultMap);
+                    }
+                    return result;
                 }
                 logger.info("Write cache for request URL: {} and query parameters: {}", url, queryParams);
                 cacheService.write(fullUrl, result);

--- a/src/main/java/org/semantics/apigateway/service/ApiAccessor.java
+++ b/src/main/java/org/semantics/apigateway/service/ApiAccessor.java
@@ -2,6 +2,7 @@ package org.semantics.apigateway.service;
 
 import lombok.AllArgsConstructor;
 import lombok.Setter;
+import org.semantics.apigateway.config.EndpointParameterMapping;
 import org.semantics.apigateway.model.responses.ApiResponse;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,8 +18,8 @@ import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Setter
 @AllArgsConstructor
@@ -46,15 +47,15 @@ public class ApiAccessor {
 
     @Async
     public CompletableFuture<Map<String, ApiResponse>> get(long timeoutMillis) {
-        return get(timeoutMillis, "");
+        return get(timeoutMillis, Map.of());
     }
 
     @Async
-    public CompletableFuture<Map<String, ApiResponse>> get(long timeoutMillis, String... query) {
+    public CompletableFuture<Map<String, ApiResponse>> get(long timeoutMillis, Map<RequestParameter, String> queryParams) {
         ForkJoinPool customThreadPool = new ForkJoinPool(Math.max(this.urls.size(), 1));
 
         List<CompletableFuture<Map.Entry<String, ApiResponse>>> futures = this.urls.entrySet().stream()
-                .map(config -> CompletableFuture.supplyAsync(() -> call(config.getKey(), config.getValue(), query), customThreadPool)
+                .map(config -> CompletableFuture.supplyAsync(() -> call(config.getKey(), config.getValue(), queryParams), customThreadPool)
                         .thenApply(response -> Map.entry(config.getKey(), response))
                 )
                 .toList();
@@ -73,15 +74,15 @@ public class ApiAccessor {
     }
 
 
-    public ApiResponse call(String url, UrlConfig urlConfig, String... query) {
+    public ApiResponse call(String url, UrlConfig urlConfig, Map<RequestParameter, String> queryParams) {
         ApiResponse result = new ApiResponse();
         String fullUrl = url;
         result.setUrl(url);
         try {
-            fullUrl = constructUrl(url, urlConfig, query);
+            fullUrl = constructUrl(url, urlConfig, queryParams);
 
             if (cacheService.exists(fullUrl) && cacheEnabled) {
-                logger.info("Cached result for request URL: {} and query parameters: {}", url, query);
+                logger.info("Cached result for request URL: {} and query parameters: {}", url, queryParams);
                 return (ApiResponse) cacheService.read(fullUrl);
             }
 
@@ -133,7 +134,7 @@ public class ApiAccessor {
                 } else {
                     result.setResponseBody((Map<String, Object>) response.getBody());
                 }
-                logger.info("Write cache for request URL: {} and query parameters: {}", url, query);
+                logger.info("Write cache for request URL: {} and query parameters: {}", url, queryParams);
                 cacheService.write(fullUrl, result);
                 return result;
             } else {
@@ -146,36 +147,69 @@ public class ApiAccessor {
         }
     }
 
-    private String constructUrl(String url, UrlConfig config, String... query) {
+    private String constructUrl(String url, UrlConfig config, Map<RequestParameter, String> requestParameters) {
         String apikey = config.apikey();
+        
+        // TODO What is the purpose of caseInsensitive?
+        // The places it is explicitly set appear to be completely random.
+        // Wherever it is explicitly set, it is set to false, which is the default value anyway.
         boolean isCaseInSensitive = config.caseInSensitive();
-        List<String> queries = new ArrayList<>(List.of(query));
-
-        if(isCaseInSensitive)
-            queries.set(0, queries.get(0).toUpperCase());
-
-        queries = queries.stream().filter(x -> !x.isEmpty()).collect(Collectors.toList());
         
-        // TODO It is assumed that the last query argument is the pagination offset. This should be handled in a safer way.
+        if(isCaseInSensitive && requestParameters.get(RequestParameter.artefact) != null)
+            requestParameters.put(RequestParameter.query, (requestParameters.get(RequestParameter.artefact)).toUpperCase());
+
         
-        if (!queries.isEmpty()) {
-            try {
-                Integer page = Integer.parseInt(queries.get(queries.size() - 1)) - 1 + config.pagination().getFirst();
-                queries = Stream.concat(queries.stream().limit(queries.size() - 1), Stream.of(page.toString())).collect(Collectors.toList());
-            } catch (NumberFormatException e) {
-                logger.info("Pagination parameter missing for URL {} with query: {}", url, queries);
-            }
+        try {
+            requestParameters.put(RequestParameter.page, "" + (Integer.parseInt(requestParameters.get(RequestParameter.page)) + config.pagination().getFirst()));
+        } catch (NumberFormatException e) {
+            logger.info("Pagination parameter missing for URL {} with query: {}", url, requestParameters);
         }
         
         if (!apikey.isEmpty()) {
-            queries.add(apikey);
+            requestParameters.put(RequestParameter.apiKey, apikey);
         }
 
-        if (queries.isEmpty()) {
+        if (requestParameters.isEmpty()) {
             return url;
         } else {
-            return String.format(url, queries.toArray());
+            return formatUrl(url, config, requestParameters);
         }
-
     }
+    
+    private final static Pattern pathParamPattern = Pattern.compile("\\{.*?}");
+    
+    private String formatUrl(String urlTemplate, UrlConfig config, Map<RequestParameter, String> queryParams) {
+        String url = pathParamPattern.matcher(urlTemplate).replaceAll(match -> {
+            String paramKey = match.group();
+            String paramValue = queryParams.get(RequestParameter.valueOf(paramKey));
+            if (paramValue == null) {
+                logger.error("No value for path parameter '{}' for url {}", paramKey, urlTemplate);
+                return "";
+            }
+            return paramValue;
+        });
+        
+        for (Map.Entry<RequestParameter, EndpointParameterMapping> entry : config.parameterMappings().entrySet()) {
+            RequestParameter key = entry.getKey();
+            EndpointParameterMapping mapping = entry.getValue();
+            String paramValue = queryParams.get(key);
+            if (paramValue != null) {
+                url = appendQueryParam(url, mapping.serializeParameter(paramValue));
+            } else if (!mapping.isOptional()) {
+                logger.error("No value for query parameter '{}' for url {}", key, urlTemplate);
+            }
+        }
+        
+        return url;
+    }
+    
+    private String appendQueryParam(String url, String param) {
+        if (url.contains("?")) {
+            url = url + "&" + param;
+        } else  {
+            url = url + "?" + param;
+        }
+        return url;
+    }
+    
 }

--- a/src/main/java/org/semantics/apigateway/service/ApiAccessor.java
+++ b/src/main/java/org/semantics/apigateway/service/ApiAccessor.java
@@ -47,7 +47,7 @@ public class ApiAccessor {
 
     @Async
     public CompletableFuture<Map<String, ApiResponse>> get(long timeoutMillis) {
-        return get(timeoutMillis, Map.of());
+        return get(timeoutMillis, new HashMap<>());
     }
 
     @Async
@@ -150,17 +150,13 @@ public class ApiAccessor {
     private String constructUrl(String url, UrlConfig config, Map<RequestParameter, String> requestParameters) {
         String apikey = config.apikey();
         
-        // TODO What is the purpose of caseInsensitive?
-        // The places it is explicitly set appear to be completely random.
-        // Wherever it is explicitly set, it is set to false, which is the default value anyway.
-        boolean isCaseInSensitive = config.caseInSensitive();
+        boolean isCaseInsensitive = config.caseInSensitive();
         
-        if(isCaseInSensitive && requestParameters.get(RequestParameter.artefact) != null)
+        if(isCaseInsensitive && requestParameters.get(RequestParameter.artefact) != null)
             requestParameters.put(RequestParameter.query, (requestParameters.get(RequestParameter.artefact)).toUpperCase());
-
         
         try {
-            requestParameters.put(RequestParameter.page, "" + (Integer.parseInt(requestParameters.get(RequestParameter.page)) + config.pagination().getFirst()));
+            requestParameters.put(RequestParameter.page, "" + (Integer.parseInt(Optional.ofNullable(requestParameters.get(RequestParameter.page)).orElse("0")) + config.pagination().getFirst()));
         } catch (NumberFormatException e) {
             logger.info("Pagination parameter missing for URL {} with query: {}", url, requestParameters);
         }
@@ -176,11 +172,11 @@ public class ApiAccessor {
         }
     }
     
-    private final static Pattern pathParamPattern = Pattern.compile("\\{.*?}");
+    private final static Pattern pathParamPattern = Pattern.compile("\\{(.*?)}");
     
     private String formatUrl(String urlTemplate, UrlConfig config, Map<RequestParameter, String> queryParams) {
         String url = pathParamPattern.matcher(urlTemplate).replaceAll(match -> {
-            String paramKey = match.group();
+            String paramKey = match.group(1);
             String paramValue = queryParams.get(RequestParameter.valueOf(paramKey));
             if (paramValue == null) {
                 logger.error("No value for path parameter '{}' for url {}", paramKey, urlTemplate);

--- a/src/main/java/org/semantics/apigateway/service/RequestParameter.java
+++ b/src/main/java/org/semantics/apigateway/service/RequestParameter.java
@@ -1,0 +1,15 @@
+package org.semantics.apigateway.service;
+
+public enum RequestParameter {
+  artefact,
+  resourceUri,
+  query,
+  childrenOf,
+  
+  offset,
+  page,
+  size,
+  pageSize,
+  
+  apiKey
+}

--- a/src/main/java/org/semantics/apigateway/service/UrlConfig.java
+++ b/src/main/java/org/semantics/apigateway/service/UrlConfig.java
@@ -1,7 +1,10 @@
 package org.semantics.apigateway.service;
 
+import org.semantics.apigateway.config.EndpointParameterMapping;
 import org.semantics.apigateway.config.Pagination;
 
-public record UrlConfig(String url, String apikey, boolean caseInSensitive, Pagination pagination) {
+import java.util.Map;
+
+public record UrlConfig(String url, String apikey, boolean caseInSensitive, Pagination pagination, Map<RequestParameter, EndpointParameterMapping> parameterMappings) {
 
 }

--- a/src/main/resources/backend_types/gnd.yml
+++ b/src/main/resources/backend_types/gnd.yml
@@ -38,7 +38,17 @@ models:
 
 endpoints:
   search:
-    path: /gnd/search?q=%s&format=json
+    path: /gnd/search?format=json
+    parameters:
+      query:
+        name: q
+        type: string
+      offset:
+        name: from
+        type: string
+      size:
+        name: size
+        type: string
     responseMapping:
       nestedJson: member
       <<: *searchResult
@@ -54,6 +64,6 @@ endpoints:
 
   concept_details:
     caseInsensitive: false
-    path: /%s/%s.json
+    path: /{artefact}/{resourceUri}.json
     responseMapping:
       <<: *searchResult

--- a/src/main/resources/backend_types/jskos.yml
+++ b/src/main/resources/backend_types/jskos.yml
@@ -36,7 +36,11 @@ models:
 
 endpoints:
   search:
-    path: /search?query=%s&properties=+notation,definition,prefLabel,altLabel,inScheme,deprecated,created,modified,issued,startDate,endDate
+    path: /search?properties=+notation,definition,prefLabel,altLabel,inScheme,deprecated,created,modified,issued,startDate,endDate
+    parameters:
+      query:
+        name: query
+        type: string
     responseMapping:
       <<: *searchResult
 
@@ -47,11 +51,18 @@ endpoints:
 
   resource_details:
     caseInsensitive: false
-    path: /voc/%s
+    path: /voc/{artefact}
     responseMapping:
       <<: *artefact
 
   concept_details:
-    path: /data?voc=%s&id=%s&properties=notation,definition,prefLabel,altLabel,inScheme,deprecated,created,modified,issued,startDate,endDate
+    path: /data?properties=notation,definition,prefLabel,altLabel,inScheme,deprecated,created,modified,issued,startDate,endDate
+    parameters:
+      artefact:
+        name: voc
+        type: string
+      resourceUri:
+        name: id
+        type: string
     responseMapping:
       <<: *searchResult

--- a/src/main/resources/backend_types/jskos2.yml
+++ b/src/main/resources/backend_types/jskos2.yml
@@ -42,7 +42,11 @@ models:
 
 endpoints:
   search:
-    path: /concepts/search?search=%s&properties=notation,definition,prefLabel,altLabel,inScheme,deprecated,created,modified,issued,startDate,endDate
+    path: /concepts/search?properties=notation,definition,prefLabel,altLabel,inScheme,deprecated,created,modified,issued,startDate,endDate
+    parameters:
+      query:
+        name: search
+        type: string
     responseMapping:
       <<: *searchResult
 
@@ -53,17 +57,38 @@ endpoints:
 
   resource_details:
     caseInsensitive: false
-    path: /voc?limit=1000000&notation=%s # jskos v2 does not support filtering by notation only by URI
+    path: /voc?limit=1000000 # jskos v2 does not support filtering by notation only by URI
+    parameters:
+      artefact:
+        name: query
+        type: pipeList
     responseMapping:
       <<: *artefact
 
   concept_details:
     caseInsensitive: false
-    path: /concepts?voc=%s&uri=%s&properties=notation,definition,prefLabel,altLabel,inScheme,deprecated,created,modified,issued,startDate,endDate,depiction
+    path: /concepts?properties=notation,definition,prefLabel,altLabel,inScheme,deprecated,created,modified,issued,startDate,endDate,depiction
+    parameters:
+      artefact:
+        name: voc
+        type: string
+      resourceUri:
+        name: uri
+        type: string
     responseMapping:
       <<: *searchResult
 
   suggest:
-    path: /concepts/suggest?search=%s&format=jskos&limit=%s&offset=%s
+    path: /concepts/suggest?format=jskos
+    parameters:
+      query:
+        name: search
+        type: string
+      offset:
+        name: offset
+        type: string
+      size:
+        name: limit
+        type: string
     responseMapping:
       <<: *searchResult

--- a/src/main/resources/backend_types/mod.yml
+++ b/src/main/resources/backend_types/mod.yml
@@ -19,7 +19,11 @@ models:
 
 endpoints:
   search:
-    path: /search?query=%s
+    path: /search
+    parameters:
+      query:
+        name: query
+        type: string
     responseMapping:
       nestedJson: member
       <<: *searchResult
@@ -64,11 +68,19 @@ endpoints:
       wasGeneratedBy: wasGeneratedBy
       includedInDataCatalog: includedInDataCatalog
   concept_details:
-    path: ontologies/%s/classes/%s?apikey=%s
+    path: ontologies/{artefact}/classes/{resourceUri}
+    parameters:
+      apiKey:
+        name: apikey
+        type: string
     responseMapping:
       <<: *searchResult
   resource_details:
-    path: ontologies/%s?apikey=%s
+    path: ontologies/{artefact}
+    parameters:
+      apiKey:
+        name: apikey
+        type: string
     responseMapping:
       nestedJson: ""
       label: title
@@ -109,7 +121,11 @@ endpoints:
       includedInDataCatalog: includedInDataCatalog
 
   concepts:
-    path: /ontologies/%s/classes?page=%s
+    path: /ontologies/{artefact}/classes
+    parameters:
+      page:
+        name: page
+        type: string
     responseMapping:
       nestedJson: member
       totalCount: totalItems
@@ -117,7 +133,11 @@ endpoints:
       <<: *searchResult
 
   properties:
-    path: /ontologies/%s/properties?page=%s
+    path: /ontologies/{artefact}/properties
+    parameters:
+      page:
+        name: page
+        type: string
     responseMapping:
       nestedJson: member
       totalCount: totalItems
@@ -125,12 +145,16 @@ endpoints:
       <<: *searchResult
 
   property_details:
-    path: ontologies/%s/properties/%s
+    path: ontologies/{artefact}/properties/{resourceUri}
     responseMapping:
       <<: *searchResult
 
   individuals:
-    path: /ontologies/%s/instances?page=%s
+    path: /ontologies/{artefact}/instances
+    parameters:
+      page:
+        name: page
+        type: string
     responseMapping:
       nestedJson: member
       totalCount: totalItems
@@ -138,12 +162,16 @@ endpoints:
       <<: *searchResult
 
   individual_details:
-    path: ontologies/%s/instances/%s
+    path: ontologies/{artefact}/instances/{resourceUri}
     responseMapping:
       <<: *searchResult
 
   schemes:
-    path: ontologies/%s/schemes?page=%s
+    path: ontologies/{artefact}/schemes
+    parameters:
+      page:
+        name: page
+        type: string
     responseMapping:
       nestedJson: member
       totalCount: totalItems
@@ -151,12 +179,16 @@ endpoints:
       <<: *searchResult
 
   scheme_details:
-    path: ontologies/%s/schemes/%s
+    path: ontologies/{artefact}/schemes/{resourceUri}
     responseMapping:
       <<: *searchResult
 
   collections:
-    path: ontologies/%s/collections?page=%s
+    path: ontologies/{artefact}/collections
+    parameters:
+      page:
+        name: page
+        type: string
     responseMapping:
       nestedJson: member
       totalCount: totalItems
@@ -164,7 +196,7 @@ endpoints:
       <<: *searchResult
 
   collection_details:
-    path: ontologies/%s/collections/%s
+    path: ontologies/{artefact}/collections/{resourceUri}
     responseMapping:
       <<: *searchResult
 

--- a/src/main/resources/backend_types/nerc.yml
+++ b/src/main/resources/backend_types/nerc.yml
@@ -55,7 +55,11 @@ models:
     modified: modified
 endpoints:
   search:
-    path: /search/content?q=%s
+    path: /search/content
+    parameters:
+      query:
+        name: q
+        type: string
     responseMapping:
       nestedJson: "member"
       totalCount: totalItems
@@ -68,17 +72,29 @@ endpoints:
       <<: *artefact
 
   concept_details:
-    path: /artefacts/%s/concepts/%s?apikey=%s
+    path: /artefacts/{artefact}/concepts/{resourceUri}
+    parameters:
+      apiKey:
+        name: apikey
+        type: string
     responseMapping:
       <<: *searchResult
 
   resource_details:
-    path: /artefacts/%s?apikey=%s
+    path: /artefacts/{artefact}
+    parameters:
+      apiKey:
+        name: apikey
+        type: string
     responseMapping:
       <<: *artefact
 
   concepts:
-    path: /artefacts/%s/concepts?page=%s
+    path: /artefacts/{artefact}/concepts
+    parameters:
+      page:
+        name: page
+        type: string
     responseMapping:
       nestedJson: "member"
       totalCount: totalItems
@@ -86,7 +102,11 @@ endpoints:
       <<: *searchResult
 
   properties:
-    path: /artefacts/%s/properties?page=%s
+    path: /artefacts/{artefact}/properties
+    parameters:
+      page:
+        name: page
+        type: string
     responseMapping:
       nestedJson: member
       totalCount: totalItems
@@ -94,12 +114,16 @@ endpoints:
       <<: *searchResult
 
   property_details:
-    path: /artefacts/%s/properties/%s
+    path: /artefacts/{artefact}/properties/{resourceUri}
     responseMapping:
       <<: *searchResult
 
   schemes:
-    path: /artefacts/%s/schemes?page=%s
+    path: /artefacts/{artefact}/schemes
+    parameters:
+      page:
+        name: page
+        type: string
     responseMapping:
       nestedJson: member
       totalCount: totalItems
@@ -107,12 +131,16 @@ endpoints:
       <<: *searchResult
 
   scheme_details:
-    path: /artefacts/%s/schemes/%s
+    path: /artefacts/{artefact}/schemes/{resourceUri}
     responseMapping:
       <<: *searchResult
 
   collections:
-    path: /artefacts/%s/collections?page=%s
+    path: /artefacts/{artefact}/collections
+    parameters:
+      page:
+        name: page
+        type: string
     responseMapping:
       nestedJson: member
       totalCount: totalItems
@@ -120,6 +148,6 @@ endpoints:
       <<: *searchResult
 
   collection_details:
-    path: /artefacts/%s/collections/%s
+    path: /artefacts/{artefact}/collections/{resourceUri}
     responseMapping:
       <<: *searchResult

--- a/src/main/resources/backend_types/ols.yml
+++ b/src/main/resources/backend_types/ols.yml
@@ -31,7 +31,11 @@ models:
 
 endpoints:
   search:
-    path: search?q=%s
+    path: search
+    parameters:
+      query:
+        name: q
+        type: string
     responseMapping:
       nestedJson: response
       collectionFilter: ontology
@@ -53,7 +57,14 @@ endpoints:
       <<: *artefact
 
   concepts:
-    path: terms?id=%s&size=50&page=%s
+    path: terms?size=50
+    parameters:
+      resourceUri:
+        name: id
+        type: string
+      page:
+        name: page
+        type: string
     caseInsensitive: false
     responseMapping:
       nestedJson: _embedded
@@ -63,7 +74,14 @@ endpoints:
       <<: *term
 
   properties:
-    path: properties?id=%s&size=50&page=%s
+    path: properties?size=50
+    parameters:
+      resourceUri:
+        name: id
+        type: string
+      page:
+        name: page
+        type: string
     responseMapping:
       nestedJson: _embedded
       page: page->number
@@ -72,28 +90,40 @@ endpoints:
       <<: *term
 
   concept_details:
-    path: ontologies/%s/terms?iri=%s
+    path: ontologies/{artefact}/terms
+    parameters:
+      resourceUri:
+        name: iri
+        type: string
     responseMapping:
       nestedJson: _embedded
       key: terms
       <<: *term
 
   property_details:
-    path: ontologies/%s/properties?iri=%s
+    path: ontologies/{artefact}/properties
+    parameters:
+      resourceUri:
+        name: iri
+        type: string
     responseMapping:
       nestedJson: _embedded
       key: properties
       <<: *term
 
   resource_details:
-    path: ontologies/%s
+    path: ontologies/{artefact}
     responseMapping:
       nestedJson: ""
       key: ""
       <<: *artefact
 
   individuals:
-    path: /ontologies/%s/individuals?page=%s&size=50
+    path: /ontologies/{artefact}/individuals?size=50
+    parameters:
+      page:
+        name: page
+        type: string
     responseMapping:
       nestedJson: _embedded
       page: page->number
@@ -102,14 +132,18 @@ endpoints:
       <<: *term
 
   individual_details:
-    path: ontologies/%s/individuals?iri=%s
+    path: ontologies/{artefact}/individuals
+    parameters:
+      resourceUri:
+        name: iri
+        type: string
     responseMapping:
       nestedJson: _embedded
       key: individuals
       <<: *term
 
   concepts_roots:
-    path: ontologies/%s/terms/roots?size=1000
+    path: ontologies/{artefact}/terms/roots?size=1000
     responseMapping:
       nestedJson: _embedded
       key: terms
@@ -117,7 +151,7 @@ endpoints:
       hasChildren: has_children
 
   concepts_children:
-    path: ontologies/%s/terms/%s/hierarchicalChildren
+    path: ontologies/{artefact}/terms/{resourceUri}/hierarchicalChildren
     responseMapping:
       nestedJson: _embedded
       key: terms
@@ -125,7 +159,7 @@ endpoints:
       hasChildren: has_children
 
   concept_tree:
-    path: ontologies/%s/terms/%s/hierarchicalAncestors
+    path: ontologies/{artefact}/terms/{resourceUri}/hierarchicalAncestors
     responseMapping:
       nestedJson: _embedded
       key: terms
@@ -133,11 +167,21 @@ endpoints:
       hasChildren: has_children
 
   suggest:
-    path: /suggest?q=%s&rows=%s&start=%s
+    path: /select
+    parameters:
+      query:
+        name: q
+        type: string
+      size:
+        name: rows
+        type: string
+      offset:
+        name: start
+        type: string
     responseMapping:
       nestedJson: response
       key: docs
-      iri: autosuggest
+      iri: iri
       label: autosuggest
       totalCount: response->numFound
       page: page->start

--- a/src/main/resources/backend_types/ols2.yml
+++ b/src/main/resources/backend_types/ols2.yml
@@ -34,15 +34,11 @@ models:
 
 endpoints:
   search:
-    path: /entities/search
+    path: /entities
     parameters:
       query:
-        name: q
+        name: search
         type: string
-      childrenOf:
-        name: childrenOf
-        type: repeatedKeyList
-        optional: true
     responseMapping:
       collectionFilter: ontologyId
       nestedJson: elements

--- a/src/main/resources/backend_types/ols2.yml
+++ b/src/main/resources/backend_types/ols2.yml
@@ -34,7 +34,15 @@ models:
 
 endpoints:
   search:
-    path: /entities?search=%s
+    path: /entities/search
+    parameters:
+      query:
+        name: q
+        type: string
+      childrenOf:
+        name: childrenOf
+        type: repeatedKeyList
+        optional: true
     responseMapping:
       collectionFilter: ontologyId
       nestedJson: elements
@@ -49,7 +57,12 @@ endpoints:
       <<: *artefact
 
   concepts:
-    path: /ontologies/%s/classes?page=%s&size=50
+    path: /ontologies/{artefact}/classes?size=50
+    parameters:
+      page:
+        name: page
+        type: string
+        optional: true
     responseMapping:
       nestedJson: elements
       totalCount: totalElements
@@ -57,7 +70,12 @@ endpoints:
       <<: *term
 
   properties:
-    path: /ontologies/%s/properties?page=%s&size=50
+    path: /ontologies/{artefact}/properties?size=50
+    parameters:
+      page:
+        name: page
+        type: string
+        optional: true
     responseMapping:
       nestedJson: elements
       totalCount: totalElements
@@ -65,26 +83,39 @@ endpoints:
       <<: *term
 
   concept_details:
-    path: /ontologies/%s/classes?iri=%s
+    path: /ontologies/{artefact}/classes
+    parameters:
+      resourceUri:
+        name: iri
+        type: string
     responseMapping:
       nestedJson: elements
       <<: *term
 
   property_details:
-    path: /ontologies/%s/properties?iri=%s
+    path: /ontologies/{artefact}/properties
+    parameters:
+      resourceUri:
+        name: iri
+        type: string
     responseMapping:
       nestedJson: elements
       <<: *term
 
   resource_details:
-    path: /ontologies/%s
+    path: /ontologies/{artefact}
     responseMapping:
       nestedJson: ""
       key: ""
       <<: *artefact
 
   individuals:
-    path: /ontologies/%s/individuals?page=%s&size=50
+    path: /ontologies/{artefact}/individuals?size=50
+    parameters:
+      page:
+        name: page
+        type: string
+        optional: true
     responseMapping:
       nestedJson: elements
       totalCount: totalElements
@@ -92,20 +123,24 @@ endpoints:
       <<: *term
 
   individual_details:
-    path: /ontologies/%s/individuals?iri=%s
+    path: /ontologies/{artefact}/individuals
+    parameters:
+      resourceUri:
+        name: iri
+        type: string
     responseMapping:
       nestedJson: elements
       <<: *term
 
   concepts_roots:
-    path: /ontologies/%s/classes?hasDirectParents=false&size=1000&lang=en&includeObsoleteEntities=false
+    path: /ontologies/{artefact}/classes?hasDirectParents=false&size=1000&lang=en&includeObsoleteEntities=false
     responseMapping:
       nestedJson: elements
       <<: *term
       hasChildren: hasDirectChildren
 
   concepts_children:
-    path: /ontologies/%s/classes/%s/hierarchicalChildren?size=1000&lang=en&includeObsoleteEntities=false
+    path: /ontologies/{artefact}/classes/{resourceUri}/hierarchicalChildren?size=1000&lang=en&includeObsoleteEntities=false
     caseInsensitive: false
     responseMapping:
       nestedJson: elements
@@ -115,7 +150,7 @@ endpoints:
       hasChildren: hasDirectChildren
 
   concept_tree:
-    path: /ontologies/%s/classes/%s/hierarchicalAncestors?page=0&size=10000&lang=en
+    path: /ontologies/{artefact}/classes/{resourceUri}/hierarchicalAncestors?page=0&size=10000&lang=en
     caseInsensitive: false
     responseMapping:
       nestedJson: elements

--- a/src/main/resources/backend_types/ontoportal.yml
+++ b/src/main/resources/backend_types/ontoportal.yml
@@ -62,20 +62,38 @@ models:
 
 endpoints:
   search:
-    path: /search?q=%s&apikey=%s
+    path: /search
+    parameters:
+      query:
+        name: q
+        type: string
+      apiKey:
+        name: apikey
+        type: string
     responseMapping:
       nestedJson: collection
       collectionFilter: ontologies
       <<: *searchResult
 
   resources:
-    path: /submissions?apikey=%s&display_links=true&display_context=false&display=ontology,description,URI,released,modificationDate,alternative,version,status,versionIRI,hasLicense,contact,hasCreator,identifier,keyword,naturalLanguage,publisher,homepage,hasDomain,accrualMethod,accrualPeriodicity,publication,hasContributor,coverage,hasFormat,copyrightHolder,competencyQuestion,wasGeneratedBy,includedInDataCatalog,ontologyRelatedTo,usedOntologyEngineeringTool,keywords,obsolete&lang=en
+    path: /submissions?display_links=true&display_context=false&display=ontology,description,URI,released,modificationDate,alternative,version,status,versionIRI,hasLicense,contact,hasCreator,identifier,keyword,naturalLanguage,publisher,homepage,hasDomain,accrualMethod,accrualPeriodicity,publication,hasContributor,coverage,hasFormat,copyrightHolder,competencyQuestion,wasGeneratedBy,includedInDataCatalog,ontologyRelatedTo,usedOntologyEngineeringTool,keywords,obsolete&lang=en
+    parameters:
+      apiKey:
+        name: apikey
+        type: string
     responseMapping:
       nestedJson: collection
       <<: *artefact
 
   concepts:
-    path: /ontologies/%s/classes?page=%s&apikey=%s&pagesize=50&display_links=true&display_context=false&lang=en
+    path: /ontologies/{artefact}/classes?pagesize=50&display_links=true&display_context=false&lang=en
+    parameters:
+      page:
+        name: page
+        type: string
+      apiKey:
+        name: apikey
+        type: string
     responseMapping:
       nestedJson: collection
       totalCount: totalCount
@@ -83,7 +101,14 @@ endpoints:
       <<: *term
 
   properties:
-    path: /ontologies/%s/properties?page=%s&apikey=%s&pagesize=50&display_links=true&display_context=false&lang=en
+    path: /ontologies/{artefact}/properties?pagesize=50&display_links=true&display_context=false&lang=en
+    parameters:
+      page:
+        name: page
+        type: string
+      apiKey:
+        name: apikey
+        type: string
     responseMapping:
       nestedJson: collection
       totalCount: totalCount
@@ -91,22 +116,41 @@ endpoints:
       <<: *term
 
   concept_details:
-    path: ontologies/%s/classes/%s?apikey=%s&lang=en
+    path: ontologies/{artefact}/classes/{resourceUri}?lang=en
+    parameters:
+      apiKey:
+        name: apikey
+        type: string
     responseMapping:
       <<: *term
 
   property_details:
-    path: ontologies/%s/properties/%s?apikey=%s&lang=en
+    path: ontologies/{artefact}/properties/{resourceUri}?lang=en
+    parameters:
+      apiKey:
+        name: apikey
+        type: string
     responseMapping:
       <<: *term
 
   resource_details:
-    path: ontologies/%s/latest_submission?apikey=%s&display=all&lang=en
+    path: ontologies/{artefact}/latest_submission?display=all&lang=en
+    parameters:
+      apiKey:
+        name: apikey
+        type: string
     responseMapping:
       <<: *artefact
 
   individuals:
-    path: /ontologies/%s/instances?page=%s&apikey=%s&pagesize=50&display_links=true&display_context=false&lang=en
+    path: /ontologies/{artefact}/instances?pagesize=50&display_links=true&display_context=false&lang=en
+    parameters:
+      page:
+        name: page
+        type: string
+      apiKey:
+        name: apikey
+        type: string
     responseMapping:
       nestedJson: collection
       totalCount: totalCount
@@ -114,45 +158,88 @@ endpoints:
       <<: *term
 
   individual_details:
-    path: ontologies/%s/instances/%s?apikey=%s&lang=en
+    path: ontologies/{artefact}/instances/{resourceUri}?lang=en
+    parameters:
+      apiKey:
+        name: apikey
+        type: string
     responseMapping:
       <<: *term
 
   schemes:
-    path: ontologies/%s/schemes?page=%s&apikey=%s&lang=en
+    path: ontologies/{artefact}/schemes?lang=en
+    parameters:
+      page:
+        name: page
+        type: string
+      apiKey:
+        name: apikey
+        type: string
     responseMapping:
       <<: *term
 
   scheme_details:
-    path: ontologies/%s/schemes/%s?apikey=%s&lang=en
+    path: ontologies/{artefact}/schemes/{resourceUri}?lang=en
+    parameters:
+      apiKey:
+        name: apikey
+        type: string
     responseMapping:
       <<: *term
 
   collections:
-    path: ontologies/%s/collections?page=%s&apikey=%s&lang=en
+    path: ontologies/{artefact}/collections?lang=en
+    parameters:
+      page:
+        name: page
+        type: string
+      apiKey:
+        name: apikey
+        type: string
     responseMapping:
       <<: *term
 
   collection_details:
-    path: ontologies/%s/collections/%s?apikey=%s&lang=en
+    path: ontologies/{artefact}/collections/{resourceUri}?lang=en
+    parameters:
+      apiKey:
+        name: apikey
+        type: string
     responseMapping:
       <<: *term
 
   concepts_roots:
-    path: ontologies/%s/classes/roots?apikey=%s&lang=en&display=prefLabel,definition,synonym,created,modified,obsolete,hasChildren
+    path: ontologies/{artefact}/classes/roots?lang=en&display=prefLabel,definition,synonym,created,modified,obsolete,hasChildren
+    parameters:
+      apiKey:
+        name: apikey
+        type: string
     responseMapping:
       <<: *term
       hasChildren: hasChildren
+
   concepts_children:
-    path: ontologies/%s/classes/%s/children?page=%s&apikey=%s&lang=en&display=prefLabel,definition,synonym,created,modified,obsolete,hasChildren
+    path: ontologies/{artefact}/classes/{resourceUri}/children?lang=en&display=prefLabel,definition,synonym,created,modified,obsolete,hasChildren
+    parameters:
+      page:
+        name: page
+        type: string
+      apiKey:
+        name: apikey
+        type: string
     responseMapping:
       nestedJson: collection
       totalCount: totalCount
       page: page
       <<: *term
       hasChildren: hasChildren
+
   concept_tree:
-    path: ontologies/%s/classes/%s/tree?apikey=%s&lang=en&display=prefLabel,definition,synonym,URI,created,modified,obsolete,hasChildren,children
+    path: ontologies/{artefact}/classes/{resourceUri}/tree?lang=en&display=prefLabel,definition,synonym,URI,created,modified,obsolete,hasChildren,children
+    parameters:
+      apiKey:
+        name: apikey
+        type: string
     responseMapping:
       <<: *term
       hasChildren: hasChildren

--- a/src/main/resources/backend_types/skosmos.yml
+++ b/src/main/resources/backend_types/skosmos.yml
@@ -16,7 +16,14 @@ models:
 
 endpoints:
   search:
-    path: /search?query=%s*&lang=en&fields=scopeNote
+    path: /search?lang=en&fields=scopeNote
+    parameters:
+      query:
+        name: query
+        type: stringAsterisk
+      childrenOf:
+        name: children
+        type: string
     responseMapping:
       nestedJson: results
       <<: *term
@@ -33,12 +40,23 @@ endpoints:
       descriptions: title
 
   concepts:
-    path: /agrovoc/label?acronym=%s
+    path: /agrovoc/label
+    parameters:
+      artefact:
+        name: acronym
+        type: string
     responseMapping:
       <<: *term
 
   concept_details:
-    path: /agrovoc/label?acronym=%s&uri=%s
+    path: /agrovoc/label
+    parameters:
+      artefact:
+        name: acronym
+        type: string
+      resourceUri:
+        name: uri
+        type: string
     responseMapping:
       <<: *term
 
@@ -53,7 +71,7 @@ endpoints:
       shortForm: id
 
   concepts_roots:
-    path: /%s/topConcepts?lang=en
+    path: /{artefact}/topConcepts?lang=en
     caseInsensitive: false
     responseMapping:
       nestedJson: topconcepts
@@ -61,7 +79,11 @@ endpoints:
       hasChildren: hasChildren
 
   concepts_children:
-    path: /%s/children?uri=%s&lang=en
+    path: /{artefact}/children?lang=en
+    parameters:
+      resourceUri:
+        name: uri
+        type: string
     caseInsensitive: false
     responseMapping:
       nestedJson: narrower

--- a/src/main/resources/backend_types/skosmos.yml
+++ b/src/main/resources/backend_types/skosmos.yml
@@ -40,7 +40,7 @@ endpoints:
       descriptions: title
 
   concepts:
-    path: /agrovoc/label
+    path: /{artefact}/label
     parameters:
       artefact:
         name: acronym
@@ -49,7 +49,7 @@ endpoints:
       <<: *term
 
   concept_details:
-    path: /agrovoc/label
+    path: /{artefact}/label
     parameters:
       artefact:
         name: acronym
@@ -61,7 +61,7 @@ endpoints:
       <<: *term
 
   resource_details:
-    path: /agrovoc
+    path: /{artefact}
     responseMapping:
       label: id
       iri: conceptschemes->uri|uri

--- a/src/test/java/org/semantics/apigateway/ArtefactDataServiceTest.java
+++ b/src/test/java/org/semantics/apigateway/ArtefactDataServiceTest.java
@@ -87,7 +87,7 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
         mockApiAccessor("artefact_individual", artefactsService.getAccessor());
         CommonRequestParams params = new CommonRequestParams();
         params.setDatabase("ols2");
-        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefactIndividual("FOODON", "http://purl.obolibrary.org/obo/GAZ_00000464", new CommonRequestParams(), apiAccessor, null);
+        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefactIndividual("FOODON", "http://purl.obolibrary.org/obo/GAZ_00000464", params, apiAccessor, null);
         assertMapEquality(response, createOls2FoodOnInstanceFixture());
 
         params = new CommonRequestParams();


### PR DESCRIPTION
This PR

- includes a comprehensive overhaul of the mechanism for mapping endpoint URLs
- replaces the positional placeholders in the endpoint url templates by named ones
- adds the ability to specify parameter types with specialized serializers, such as
  - strings: `key=value`
  - comma separated lists: `key=value1,value2,value3`
  - pipe separated lists: `key=value1|value2|value3`
  - JSON lists: `key=[value1,value2,value3]`
  - key repeated lists: `key=value1&key=value2&key=value3`

Before:

```yaml
  concept_details:
    path: ontologies/%s/classes/%s?apikey=%s
```

After:

```yaml
  concept_details:
    path: ontologies/{artefact}/classes/{resourceUri}
    parameters:
      apiKey:
        name: apikey
        type: string
```
  
Resolves #182, #123 