### PR TITLE
Add server-side Matomo tracking for gateway endpoints

### DIFF
--- a/.github/workflows/prod-deployment.yml
+++ b/.github/workflows/prod-deployment.yml
@@ -115,6 +115,27 @@ jobs:
             --namespace='ts4nfdi' \
             --dry-run=client -o yaml | kubectl apply -f -
 
+      - name: Create Kubernetes configmap for MATOMO_ENABLED
+        run: |
+          kubectl create configmap matomo-enabled \
+            --from-literal=MATOMO_ENABLED=${{ vars.MATOMO_ENABLED }} \
+            --namespace='ts4nfdi' \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Create Kubernetes configmap for MATOMO_URL
+        run: |
+          kubectl create configmap matomo-url \
+            --from-literal=MATOMO_URL=${{ vars.MATOMO_URL }} \
+            --namespace='ts4nfdi' \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Create Kubernetes configmap for MATOMO_SITE_ID
+        run: |
+          kubectl create configmap matomo-site-id \
+            --from-literal=MATOMO_SITE_ID=${{ vars.MATOMO_SITE_ID }} \
+            --namespace='ts4nfdi' \
+            --dry-run=client -o yaml | kubectl apply -f -
+
       - name: Deploy to Kubernetes
         uses: stefanprodan/kube-tools@v1
         with:

--- a/src/main/java/org/semantics/apigateway/tracking/MatomoEvent.java
+++ b/src/main/java/org/semantics/apigateway/tracking/MatomoEvent.java
@@ -1,0 +1,32 @@
+package org.semantics.apigateway.tracking;
+
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * One tracked request, captured by {@link MatomoTrackingInterceptor} and queued for delivery by
+ * {@link MatomoTracker}.
+ *
+ * @param url         the request url with the <em>uri template</em> as its path, never the resolved path, so that
+ *                    endpoints carrying an ontology iri in the path do not explode the Matomo action cardinality
+ * @param actionName  hierarchical Matomo action name, slash separated, e.g. {@code Search / GET /search}
+ * @param visitorId   16 character hexadecimal visitor id
+ * @param userId      username of the authenticated user, or null
+ * @param searchQuery when set, the event is reported as a Matomo site search instead of a page view
+ * @param dimensions  custom dimension index to value
+ */
+public record MatomoEvent(
+        String url,
+        String actionName,
+        String visitorId,
+        String userId,
+        String userAgent,
+        String language,
+        String referrer,
+        String clientIp,
+        String searchQuery,
+        long durationMs,
+        Instant timestamp,
+        Map<Integer, String> dimensions
+) {
+}

--- a/src/main/java/org/semantics/apigateway/tracking/MatomoProperties.java
+++ b/src/main/java/org/semantics/apigateway/tracking/MatomoProperties.java
@@ -1,0 +1,120 @@
+package org.semantics.apigateway.tracking;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Configuration for the server side Matomo tracking of the gateway endpoints.
+ * Everything is disabled by default, so the tracking stays inert until a deployment opts in.
+ */
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "matomo")
+public class MatomoProperties {
+
+    /**
+     * Master switch. When false no interceptor is registered and no tracker bean is created.
+     */
+    private boolean enabled = false;
+
+    /**
+     * Full URL of the Matomo tracking endpoint, e.g. https://matomo.example.org/matomo.php
+     */
+    private String url = "";
+
+    /**
+     * The Matomo site id the gateway traffic belongs to.
+     */
+    private int siteId = 1;
+
+    /**
+     * Only required for parameters Matomo gates behind authentication (currently the visitor ip override).
+     */
+    private String tokenAuth = "";
+
+    /**
+     * Salt for the visitor id hash. A random one is generated at startup when left empty, which means
+     * visitor ids are not comparable across restarts. Set it explicitly to get stable ids.
+     */
+    private String visitorIdSalt = "";
+
+    /**
+     * Send the real client ip to Matomo. Requires tokenAuth. Without it Matomo attributes every visit to the
+     * gateway host itself, so there is no country/city reporting.
+     */
+    private boolean trackClientIp = false;
+
+    /**
+     * Anonymise the client ip by zeroing its last octet (IPv4) or its last 80 bits (IPv6) before sending.
+     * Only relevant when trackClientIp is true.
+     */
+    private boolean anonymizeClientIp = true;
+
+    /**
+     * Report the username of authenticated users to Matomo as the user id.
+     */
+    private boolean trackUserId = true;
+
+    /**
+     * Report the "query" request parameter of the search endpoints as a Matomo site search.
+     * Off by default because it records user supplied content.
+     */
+    private boolean trackSiteSearch = false;
+
+    /**
+     * Ant style patterns, matched against the request path without the context path, that must not be tracked.
+     */
+    private List<String> excludePatterns = new ArrayList<>(List.of(
+            "/actuator/**",
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
+            "/doc/api",
+            "/status/**",
+            "/auth/**",
+            "/error"
+    ));
+
+    /**
+     * Maximum number of events shipped in a single bulk request.
+     */
+    private int batchSize = 50;
+
+    /**
+     * Delay between two flushes of the event queue, in milliseconds.
+     */
+    private long flushIntervalMs = 10_000;
+
+    /**
+     * Upper bound of the in memory event queue. Events are dropped once it is full so that tracking can never
+     * slow down or break an API request.
+     */
+    private int queueCapacity = 10_000;
+
+    /**
+     * Timeout of a single bulk request towards Matomo, in milliseconds.
+     */
+    private long timeoutMs = 5_000;
+
+    /**
+     * Maps a logical dimension to the custom dimension index configured in the Matomo UI.
+     * A missing or non positive index means the dimension is not sent.
+     */
+    private Dimensions dimensions = new Dimensions();
+
+    @Getter
+    @Setter
+    public static class Dimensions {
+        /** Index of the custom dimension receiving the "database" request parameter. */
+        private int database = 0;
+        /** Index of the custom dimension receiving the "targetDbSchema" request parameter. */
+        private int targetDbSchema = 0;
+        /** Index of the custom dimension receiving the HTTP response status. */
+        private int status = 0;
+        /** Index of the custom dimension receiving the authentication kind (anonymous / authenticated). */
+        private int auth = 0;
+    }
+}

--- a/src/main/java/org/semantics/apigateway/tracking/MatomoTracker.java
+++ b/src/main/java/org/semantics/apigateway/tracking/MatomoTracker.java
@@ -1,0 +1,238 @@
+package org.semantics.apigateway.tracking;
+
+import com.google.gson.Gson;
+import jakarta.annotation.PreDestroy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Buffers {@link MatomoEvent}s and ships them to Matomo with the bulk tracking API.
+ *
+ * <p>Requests never wait for Matomo: {@link #track(MatomoEvent)} only offers to a bounded queue and returns.
+ * A scheduled flush drains the queue in fifo order, which also satisfies Matomo's requirement that the entries of a
+ * bulk request are ordered oldest first.
+ *
+ * <p>Only created when {@code matomo.enabled} is true, like the rest of the tracking.
+ */
+@Service
+@ConditionalOnProperty(prefix = "matomo", name = "enabled", havingValue = "true")
+public class MatomoTracker {
+
+    private static final Logger logger = LoggerFactory.getLogger(MatomoTracker.class);
+
+    /** Matomo drops a bulk request whose entries are older than this without a token_auth. */
+    private static final Duration MAX_UNAUTHENTICATED_BACKDATING = Duration.ofHours(24);
+
+    private static final Duration DROP_LOG_INTERVAL = Duration.ofMinutes(1);
+
+    private final MatomoProperties properties;
+    private final WebClient webClient;
+    private final Gson gson = new Gson();
+
+    private final BlockingQueue<MatomoEvent> queue;
+    private final AtomicLong dropped = new AtomicLong();
+    private final AtomicLong lastDropLogNanos = new AtomicLong();
+
+    public MatomoTracker(MatomoProperties properties, WebClient.Builder webClientBuilder) {
+        this.properties = properties;
+        this.queue = new ArrayBlockingQueue<>(Math.max(1, properties.getQueueCapacity()));
+        this.webClient = webClientBuilder.build();
+    }
+
+    /**
+     * Queues an event. Returns false and increments the dropped counter when the queue is full, rather than blocking
+     * the request thread: losing analytics is always preferable to slowing down the API.
+     */
+    public boolean track(MatomoEvent event) {
+        if (event == null) {
+            return false;
+        }
+        if (queue.offer(event)) {
+            return true;
+        }
+        long total = dropped.incrementAndGet();
+        logDropped(total);
+        return false;
+    }
+
+    @Scheduled(fixedDelayString = "${matomo.flush-interval-ms:10000}")
+    public void flush() {
+        List<MatomoEvent> batch = new ArrayList<>(properties.getBatchSize());
+        queue.drainTo(batch, properties.getBatchSize());
+        if (batch.isEmpty()) {
+            return;
+        }
+        send(batch);
+    }
+
+    /**
+     * Drains whatever is still buffered on shutdown so a restart does not silently lose the queue.
+     * Unlike the scheduled flush this one waits for the response, because the reactive machinery is torn down as
+     * soon as this method returns and an unfinished request would simply be dropped.
+     */
+    @PreDestroy
+    public void flushOnShutdown() {
+        List<MatomoEvent> remaining = new ArrayList<>();
+        queue.drainTo(remaining);
+        for (int i = 0; i < remaining.size(); i += properties.getBatchSize()) {
+            send(remaining.subList(i, Math.min(i + properties.getBatchSize(), remaining.size())), true);
+        }
+    }
+
+    private void send(List<MatomoEvent> batch) {
+        send(batch, false);
+    }
+
+    private void send(List<MatomoEvent> batch, boolean blocking) {
+        List<String> requests = new ArrayList<>(batch.size());
+        for (MatomoEvent event : batch) {
+            requests.add(buildQuery(event));
+        }
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("requests", requests);
+        if (needsTokenAuth()) {
+            body.put("token_auth", properties.getTokenAuth());
+        }
+        String payload = gson.toJson(body);
+
+        if (properties.getUrl() == null || properties.getUrl().isBlank()) {
+            logger.warn("matomo.url is not configured, discarding {} event(s)", batch.size());
+            return;
+        }
+
+        // Set org.semantics.apigateway.tracking=TRACE to see the exact payload while verifying an integration.
+        logger.trace("Matomo bulk payload: {}", payload);
+
+        try {
+            Mono<ResponseEntity<Void>> call = webClient.post()
+                    .uri(properties.getUrl())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(payload)
+                    .retrieve()
+                    .toBodilessEntity()
+                    .timeout(Duration.ofMillis(properties.getTimeoutMs()))
+                    .doOnNext(response -> logger.debug("Sent {} event(s) to Matomo, response {}",
+                            batch.size(), response.getStatusCode()))
+                    .doOnError(error -> logger.warn("Failed to send {} event(s) to Matomo: {}",
+                            batch.size(), error.toString()))
+                    .onErrorComplete();
+
+            if (blocking) {
+                call.block(Duration.ofMillis(properties.getTimeoutMs()));
+            } else {
+                call.subscribe();
+            }
+        } catch (Exception e) {
+            // Tracking must never propagate a failure into the application.
+            logger.warn("Failed to submit {} event(s) to Matomo: {}", batch.size(), e.toString());
+        }
+    }
+
+    /**
+     * Builds one entry of the bulk "requests" array, i.e. the query string that would be sent if the event were
+     * tracked on its own.
+     */
+    String buildQuery(MatomoEvent event) {
+        StringBuilder query = new StringBuilder("?idsite=")
+                .append(properties.getSiteId())
+                .append("&rec=1")
+                // Ask for a 204 instead of the tracking gif.
+                .append("&send_image=0")
+                // Report the real time of the request, not the time the batch happens to be flushed.
+                .append("&cdt=").append(event.timestamp().getEpochSecond());
+
+        append(query, "url", event.url());
+        append(query, "action_name", event.actionName());
+        append(query, "_id", event.visitorId());
+        append(query, "ua", event.userAgent());
+        append(query, "lang", event.language());
+        append(query, "urlref", event.referrer());
+
+        if (properties.isTrackUserId()) {
+            append(query, "uid", event.userId());
+        }
+        if (properties.isTrackClientIp()) {
+            append(query, "cip", event.clientIp());
+        }
+        if (properties.isTrackSiteSearch() && isNotBlank(event.searchQuery())) {
+            append(query, "search", event.searchQuery());
+        }
+        if (event.durationMs() > 0) {
+            // Matomo expects the generation time in milliseconds.
+            query.append("&pf_srv=").append(event.durationMs());
+        }
+        if (event.dimensions() != null) {
+            event.dimensions().forEach((index, value) -> {
+                if (index != null && index > 0) {
+                    append(query, "dimension" + index, value);
+                }
+            });
+        }
+        return query.toString();
+    }
+
+    /**
+     * The token is only needed for parameters Matomo gates behind authentication. {@code cdt} is free as long as the
+     * event is younger than 24 hours, which our flush interval guarantees, so only the ip override forces a token.
+     */
+    private boolean needsTokenAuth() {
+        return properties.isTrackClientIp() && isNotBlank(properties.getTokenAuth());
+    }
+
+    private void append(StringBuilder query, String key, String value) {
+        if (!isNotBlank(value)) {
+            return;
+        }
+        query.append('&').append(key).append('=').append(URLEncoder.encode(value, StandardCharsets.UTF_8));
+    }
+
+    private boolean isNotBlank(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private void logDropped(long total) {
+        long now = System.nanoTime();
+        long last = lastDropLogNanos.get();
+        if (now - last < DROP_LOG_INTERVAL.toNanos() && last != 0) {
+            return;
+        }
+        if (lastDropLogNanos.compareAndSet(last, now)) {
+            logger.warn("Matomo event queue is full, dropped {} event(s) so far. "
+                    + "Consider raising matomo.queue-capacity or lowering matomo.flush-interval-ms.", total);
+        }
+    }
+
+    /** Number of events dropped because the queue was full. */
+    public long getDroppedCount() {
+        return dropped.get();
+    }
+
+    /** Current queue depth, exposed for tests and troubleshooting. */
+    public int getQueueSize() {
+        return queue.size();
+    }
+
+    /** Longest backdating Matomo accepts without a token, kept for documentation of the cdt choice. */
+    static Duration maxUnauthenticatedBackdating() {
+        return MAX_UNAUTHENTICATED_BACKDATING;
+    }
+}

--- a/src/main/java/org/semantics/apigateway/tracking/MatomoTracking.java
+++ b/src/main/java/org/semantics/apigateway/tracking/MatomoTracking.java
@@ -1,0 +1,28 @@
+package org.semantics.apigateway.tracking;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Overrides the Matomo action name that {@link MatomoTrackingInterceptor} derives from the springdoc
+ * {@code @Tag} and the uri template. Optional: only use it where the derived name reads badly.
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface MatomoTracking {
+
+    /**
+     * Replaces the {@code METHOD /uri/template} part of the action name.
+     */
+    String name() default "";
+
+    /**
+     * Replaces the category, which defaults to the springdoc tag of the controller.
+     * Slashes create additional levels in the Matomo page hierarchy.
+     */
+    String category() default "";
+}

--- a/src/main/java/org/semantics/apigateway/tracking/MatomoTrackingInterceptor.java
+++ b/src/main/java/org/semantics/apigateway/tracking/MatomoTrackingInterceptor.java
@@ -1,0 +1,296 @@
+package org.semantics.apigateway.tracking;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.semantics.apigateway.service.auth.AuthService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.HandlerMapping;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.HexFormat;
+import java.util.Map;
+
+/**
+ * Tracks every request handled by a controller, without touching the controllers themselves.
+ *
+ * <p>The action reported to Matomo is built from the <em>uri template</em> and the springdoc {@code @Tag} of the
+ * controller. Using the template rather than the resolved path is what keeps the number of distinct Matomo actions
+ * bounded: endpoints such as {@code /artefacts/{id}/resources/classes/{uri}} carry a full ontology iri in their path.
+ * This is also why the tracking is an interceptor and not a servlet filter, as a filter runs before handler mapping
+ * and therefore cannot see the template.
+ */
+public class MatomoTrackingInterceptor implements HandlerInterceptor {
+
+    private static final Logger logger = LoggerFactory.getLogger(MatomoTrackingInterceptor.class);
+
+    private static final String START_TIME_ATTRIBUTE = MatomoTrackingInterceptor.class.getName() + ".start";
+    private static final String CONTROLLER_SUFFIX = "Controller";
+    private static final String ANONYMOUS_USER = "anonymousUser";
+    private static final int VISITOR_ID_LENGTH = 16;
+
+    private final MatomoTracker tracker;
+    private final MatomoProperties properties;
+    private final AuthService authService;
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
+    private final String visitorIdSalt;
+
+    public MatomoTrackingInterceptor(MatomoTracker tracker, MatomoProperties properties, AuthService authService) {
+        this.tracker = tracker;
+        this.properties = properties;
+        this.authService = authService;
+        this.visitorIdSalt = resolveSalt(properties.getVisitorIdSalt());
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        if (request.getAttribute(START_TIME_ATTRIBUTE) == null) {
+            request.setAttribute(START_TIME_ATTRIBUTE, System.currentTimeMillis());
+        }
+        return true;
+    }
+
+    /**
+     * Runs after the response is complete so the duration and the outcome are known. Never throws: a tracking
+     * problem must not turn a successful response into a failure.
+     */
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
+        try {
+            if (!(handler instanceof HandlerMethod handlerMethod)) {
+                return;
+            }
+            if (isExcluded(request, handlerMethod)) {
+                return;
+            }
+            tracker.track(buildEvent(request, response, handlerMethod));
+        } catch (Exception e) {
+            logger.debug("Skipped Matomo tracking for {}: {}", request.getRequestURI(), e.toString());
+        }
+    }
+
+    private MatomoEvent buildEvent(HttpServletRequest request, HttpServletResponse response, HandlerMethod handlerMethod) {
+        String template = uriTemplate(request);
+        String clientIp = clientIp(request);
+        String username = currentUsername();
+
+        return new MatomoEvent(
+                buildUrl(request, template),
+                buildActionName(handlerMethod, request.getMethod(), template),
+                visitorId(username, clientIp, request.getHeader("User-Agent")),
+                username,
+                request.getHeader("User-Agent"),
+                request.getHeader("Accept-Language"),
+                request.getHeader("Referer"),
+                properties.isTrackClientIp() ? maybeAnonymize(clientIp) : null,
+                searchQuery(request, template),
+                duration(request),
+                Instant.now(),
+                dimensions(request, response, username)
+        );
+    }
+
+    // -- action naming -------------------------------------------------------------------------------------------
+
+    /**
+     * {@code <category> / <METHOD> <uri template>}, e.g. {@code Artefacts / Data / GET /artefacts/{id}}.
+     * Matomo splits the action name on slashes to build its page hierarchy, so this mirrors the swagger grouping
+     * that the controllers already declare.
+     */
+    String buildActionName(HandlerMethod handlerMethod, String httpMethod, String template) {
+        MatomoTracking override = findAnnotation(handlerMethod, MatomoTracking.class);
+
+        String category = override != null && !override.category().isBlank()
+                ? override.category()
+                : resolveCategory(handlerMethod);
+
+        String action = override != null && !override.name().isBlank()
+                ? override.name()
+                : httpMethod + " " + template;
+
+        return category.isBlank() ? action : category + " / " + action;
+    }
+
+    private String resolveCategory(HandlerMethod handlerMethod) {
+        Tag tag = AnnotatedElementUtils.findMergedAnnotation(handlerMethod.getMethod(), Tag.class);
+        if (tag == null) {
+            tag = AnnotatedElementUtils.findMergedAnnotation(handlerMethod.getBeanType(), Tag.class);
+        }
+        if (tag != null && !tag.name().isBlank()) {
+            return tag.name();
+        }
+        String type = handlerMethod.getBeanType().getSimpleName();
+        return type.endsWith(CONTROLLER_SUFFIX)
+                ? type.substring(0, type.length() - CONTROLLER_SUFFIX.length())
+                : type;
+    }
+
+    // -- request inspection --------------------------------------------------------------------------------------
+
+    /**
+     * The matched uri template, e.g. {@code /artefacts/{id}/resources/classes/{uri}}. Falls back to the path within
+     * the application when no pattern is exposed, which should not happen for a {@link HandlerMethod}.
+     */
+    private String uriTemplate(HttpServletRequest request) {
+        Object pattern = request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+        return pattern != null ? pattern.toString() : pathWithinApplication(request);
+    }
+
+    private String buildUrl(HttpServletRequest request, String template) {
+        StringBuffer requestUrl = request.getRequestURL();
+        String path = request.getRequestURI();
+        int pathStart = requestUrl.length() - path.length();
+        String origin = pathStart > 0 ? requestUrl.substring(0, pathStart) : "";
+        return origin + request.getContextPath() + template;
+    }
+
+    private String pathWithinApplication(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+        String contextPath = request.getContextPath();
+        if (contextPath != null && !contextPath.isEmpty() && uri.startsWith(contextPath)) {
+            uri = uri.substring(contextPath.length());
+        }
+        return uri.isEmpty() ? "/" : uri;
+    }
+
+    private boolean isExcluded(HttpServletRequest request, HandlerMethod handlerMethod) {
+        if (findAnnotation(handlerMethod, NoMatomoTracking.class) != null) {
+            return true;
+        }
+        String path = pathWithinApplication(request);
+        String template = uriTemplate(request);
+        for (String pattern : properties.getExcludePatterns()) {
+            if (pathMatcher.match(pattern, path) || pathMatcher.match(pattern, template)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private long duration(HttpServletRequest request) {
+        Object start = request.getAttribute(START_TIME_ATTRIBUTE);
+        return start instanceof Long startedAt ? System.currentTimeMillis() - startedAt : 0L;
+    }
+
+    /**
+     * Reports the search term of the search endpoints as a Matomo site search, which gives a dedicated report of what
+     * users look up in the terminologies. Returns null unless the endpoint is one of the search endpoints.
+     */
+    private String searchQuery(HttpServletRequest request, String template) {
+        if (!properties.isTrackSiteSearch()) {
+            return null;
+        }
+        if (!template.contains("/search") && !template.contains("/select")) {
+            return null;
+        }
+        String query = request.getParameter("query");
+        return query != null && !query.isBlank() ? query : null;
+    }
+
+    private Map<Integer, String> dimensions(HttpServletRequest request, HttpServletResponse response, String username) {
+        Map<Integer, String> dimensions = new HashMap<>();
+        MatomoProperties.Dimensions indices = properties.getDimensions();
+
+        putDimension(dimensions, indices.getDatabase(), request.getParameter("database"));
+        putDimension(dimensions, indices.getTargetDbSchema(), request.getParameter("targetDbSchema"));
+        putDimension(dimensions, indices.getStatus(), String.valueOf(response.getStatus()));
+        putDimension(dimensions, indices.getAuth(), username != null ? "authenticated" : "anonymous");
+
+        return dimensions;
+    }
+
+    private void putDimension(Map<Integer, String> dimensions, int index, String value) {
+        if (index > 0 && value != null && !value.isBlank()) {
+            dimensions.put(index, value);
+        }
+    }
+
+    private String currentUsername() {
+        // Deliberately not AuthService#tryGetCurrentUser, which loads the user from the database: this runs on every
+        // request and only the username is needed.
+        String username = authService.getCurrentUsername();
+        return username == null || ANONYMOUS_USER.equals(username) ? null : username;
+    }
+
+    private <A extends java.lang.annotation.Annotation> A findAnnotation(HandlerMethod handlerMethod, Class<A> type) {
+        A annotation = AnnotatedElementUtils.findMergedAnnotation(handlerMethod.getMethod(), type);
+        return annotation != null ? annotation : AnnotatedElementUtils.findMergedAnnotation(handlerMethod.getBeanType(), type);
+    }
+
+    // -- visitor identification ----------------------------------------------------------------------------------
+
+    /**
+     * Matomo expects a 16 character hexadecimal visitor id. Authenticated users get a stable pseudonym derived from
+     * their username. Anonymous visitors get one derived from ip, user agent and the current date, so that it rotates
+     * daily instead of acting as a persistent identifier.
+     */
+    String visitorId(String username, String clientIp, String userAgent) {
+        String seed = username != null
+                ? "user:" + username
+                : "anon:" + clientIp + "|" + userAgent + "|" + LocalDate.now(ZoneOffset.UTC);
+        return hash(visitorIdSalt + seed);
+    }
+
+    private String hash(String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] bytes = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(bytes).substring(0, VISITOR_ID_LENGTH);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is required to build a Matomo visitor id", e);
+        }
+    }
+
+    private static String resolveSalt(String configured) {
+        if (configured != null && !configured.isBlank()) {
+            return configured;
+        }
+        byte[] random = new byte[32];
+        new SecureRandom().nextBytes(random);
+        logger.info("No matomo.visitor-id-salt configured, generated a random one. "
+                + "Visitor ids will not be stable across restarts.");
+        return HexFormat.of().formatHex(random);
+    }
+
+    // -- client ip -----------------------------------------------------------------------------------------------
+
+    private String clientIp(HttpServletRequest request) {
+        String forwarded = request.getHeader("X-Forwarded-For");
+        if (forwarded != null && !forwarded.isBlank()) {
+            // The first hop is the original client, the rest are the proxies it went through.
+            return forwarded.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+
+    /**
+     * Zeroes the last octet of an IPv4 address, or everything after the network prefix of an IPv6 address.
+     */
+    private String maybeAnonymize(String ip) {
+        if (ip == null || ip.isBlank() || !properties.isAnonymizeClientIp()) {
+            return ip;
+        }
+        if (ip.contains(":")) {
+            String[] groups = ip.split(":");
+            StringBuilder anonymized = new StringBuilder();
+            for (int i = 0; i < 3 && i < groups.length; i++) {
+                anonymized.append(groups[i]).append(':');
+            }
+            return anonymized.append(':').toString();
+        }
+        int lastDot = ip.lastIndexOf('.');
+        return lastDot > 0 ? ip.substring(0, lastDot) + ".0" : ip;
+    }
+}

--- a/src/main/java/org/semantics/apigateway/tracking/MatomoWebConfig.java
+++ b/src/main/java/org/semantics/apigateway/tracking/MatomoWebConfig.java
@@ -1,0 +1,40 @@
+package org.semantics.apigateway.tracking;
+
+import org.semantics.apigateway.service.auth.AuthService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Registers the tracking interceptor for every endpoint. Nothing here is created unless {@code matomo.enabled=true},
+ * so the feature is inert until a deployment opts in.
+ *
+ * <p>Scheduling is enabled here rather than on the application class so that turning the tracking off also removes
+ * the flush scheduler.
+ */
+@Configuration
+@EnableScheduling
+@EnableConfigurationProperties(MatomoProperties.class)
+@ConditionalOnProperty(prefix = "matomo", name = "enabled", havingValue = "true")
+public class MatomoWebConfig implements WebMvcConfigurer {
+
+    private final MatomoTracker tracker;
+    private final MatomoProperties properties;
+    private final AuthService authService;
+
+    public MatomoWebConfig(MatomoTracker tracker, MatomoProperties properties, AuthService authService) {
+        this.tracker = tracker;
+        this.properties = properties;
+        this.authService = authService;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        // No path patterns here: every controller endpoint is tracked, and the exclusions are applied inside the
+        // interceptor so that they stay configurable at runtime through matomo.exclude-patterns.
+        registry.addInterceptor(new MatomoTrackingInterceptor(tracker, properties, authService));
+    }
+}

--- a/src/main/java/org/semantics/apigateway/tracking/NoMatomoTracking.java
+++ b/src/main/java/org/semantics/apigateway/tracking/NoMatomoTracking.java
@@ -1,0 +1,17 @@
+package org.semantics.apigateway.tracking;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Excludes a handler method, or every handler method of a controller, from Matomo tracking.
+ * Endpoints are tracked by default, so this is only needed for the exceptions.
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface NoMatomoTracking {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,3 +23,30 @@ oidc.end-session-endpoint=${OIDC_END_SESSION_ENDPOINT:https://infraproxy.nfdi-aa
 
 spring.security.oauth2.resourceserver.jwt.issuer-uri=${OIDC_ISSUER:https://infraproxy.nfdi-aai.dfn.de}
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${OIDC_JWK_SET_URI:https://infraproxy.nfdi-aai.dfn.de/idp/profile/oidc/keyset}
+
+# Matomo endpoint tracking (disabled unless MATOMO_ENABLED=true)
+matomo.enabled=${MATOMO_ENABLED:false}
+# Full tracking endpoint, e.g. https://matomo.example.org/matomo.php
+matomo.url=${MATOMO_URL:}
+# Use a separate site id when testing so the production reports stay clean
+matomo.site-id=${MATOMO_SITE_ID:}
+# Only needed when matomo.track-client-ip is true
+matomo.token-auth=${MATOMO_TOKEN_AUTH:}
+# Set explicitly to keep visitor ids stable across restarts
+matomo.visitor-id-salt=${MATOMO_VISITOR_ID_SALT:}
+# Sending real client ips requires token-auth; without it Matomo has no country/city data
+matomo.track-client-ip=${MATOMO_TRACK_CLIENT_IP:false}
+matomo.anonymize-client-ip=${MATOMO_ANONYMIZE_CLIENT_IP:true}
+matomo.track-user-id=${MATOMO_TRACK_USER_ID:true}
+# Reports the "query" parameter of the search endpoints as a Matomo site search
+matomo.track-site-search=${MATOMO_TRACK_SITE_SEARCH:false}
+matomo.batch-size=${MATOMO_BATCH_SIZE:50}
+matomo.flush-interval-ms=${MATOMO_FLUSH_INTERVAL_MS:10000}
+matomo.queue-capacity=${MATOMO_QUEUE_CAPACITY:10000}
+matomo.timeout-ms=${MATOMO_TIMEOUT_MS:5000}
+matomo.exclude-patterns=${MATOMO_EXCLUDE_PATTERNS:/actuator/**,/swagger-ui/**,/v3/api-docs/**,/doc/api,/status/**,/auth/**,/error}
+# Custom dimension indices, must match the dimensions created in the Matomo UI. 0 disables the dimension.
+matomo.dimensions.database=${MATOMO_DIMENSION_DATABASE:0}
+matomo.dimensions.target-db-schema=${MATOMO_DIMENSION_TARGET_DB_SCHEMA:0}
+matomo.dimensions.status=${MATOMO_DIMENSION_STATUS:0}
+matomo.dimensions.auth=${MATOMO_DIMENSION_AUTH:0}

--- a/src/test/java/org/semantics/apigateway/tracking/MatomoTrackerTest.java
+++ b/src/test/java/org/semantics/apigateway/tracking/MatomoTrackerTest.java
@@ -1,0 +1,110 @@
+package org.semantics.apigateway.tracking;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.Instant;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MatomoTrackerTest {
+
+    private MatomoProperties properties;
+    private MatomoTracker tracker;
+
+    @BeforeEach
+    void setUp() {
+        properties = new MatomoProperties();
+        properties.setSiteId(36);
+        properties.setUrl("https://example.de/matomo.php");
+        properties.setQueueCapacity(2);
+        tracker = new MatomoTracker(properties, WebClient.builder());
+    }
+
+    @Test
+    @DisplayName("builds a bulk entry with the mandatory Matomo parameters")
+    void buildsQueryWithMandatoryParameters() {
+        String query = tracker.buildQuery(event("Search / GET /search", null));
+
+        assertThat(query).startsWith("?idsite=36&rec=1&send_image=0&cdt=");
+        assertThat(query).contains("&url=https%3A%2F%2Fterminology.services.base4nfdi.de%2Fapi-gateway%2Fsearch");
+        assertThat(query).contains("&action_name=Search+%2F+GET+%2Fsearch");
+        assertThat(query).contains("&_id=0123456789abcdef");
+    }
+
+    @Test
+    @DisplayName("sends the real event time so queueing delay does not skew the reports")
+    void sendsEventTimestamp() {
+        Instant when = Instant.parse("2026-07-27T10:15:30Z");
+        MatomoEvent event = new MatomoEvent("https://terminology.services.base4nfdi.de/api-gateway/search", "Search / GET /search",
+                "0123456789abcdef", null, null, null, null, null, null, 0, when, Map.of());
+
+        assertThat(tracker.buildQuery(event)).contains("&cdt=" + when.getEpochSecond());
+    }
+
+    @Test
+    @DisplayName("only writes custom dimensions with a positive index")
+    void writesOnlyConfiguredDimensions() {
+        String query = tracker.buildQuery(event("Search / GET /search", Map.of(1, "ols", 0, "ignored")));
+
+        assertThat(query).contains("&dimension1=ols");
+        assertThat(query).doesNotContain("dimension0");
+    }
+
+    @Test
+    @DisplayName("omits the search parameter unless site search tracking is enabled")
+    void omitsSearchUnlessEnabled() {
+        MatomoEvent event = new MatomoEvent("https://terminology.services.base4nfdi.de/api-gateway/search", "Search / GET /search",
+                "0123456789abcdef", null, null, null, null, null, "plant", 0, Instant.now(), Map.of());
+
+        assertThat(tracker.buildQuery(event)).doesNotContain("&search=");
+
+        properties.setTrackSiteSearch(true);
+        assertThat(tracker.buildQuery(event)).contains("&search=plant");
+    }
+
+    @Test
+    @DisplayName("omits the client ip unless ip tracking is enabled")
+    void omitsClientIpUnlessEnabled() {
+        MatomoEvent event = new MatomoEvent("https://terminology.services.base4nfdi.de/api-gateway/search", "Search / GET /search",
+                "0123456789abcdef", null, null, null, null, "203.0.113.0", null, 0, Instant.now(), Map.of());
+
+        assertThat(tracker.buildQuery(event)).doesNotContain("&cip=");
+
+        properties.setTrackClientIp(true);
+        assertThat(tracker.buildQuery(event)).contains("&cip=203.0.113.0");
+    }
+
+    @Test
+    @DisplayName("drops events instead of blocking once the queue is full")
+    void dropsEventsWhenQueueIsFull() {
+        assertThat(tracker.track(event("a", null))).isTrue();
+        assertThat(tracker.track(event("b", null))).isTrue();
+
+        assertThat(tracker.track(event("c", null))).isFalse();
+        assertThat(tracker.getDroppedCount()).isEqualTo(1);
+        assertThat(tracker.getQueueSize()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("a null event is ignored rather than queued")
+    void ignoresNullEvents() {
+        assertThat(tracker.track(null)).isFalse();
+        assertThat(tracker.getQueueSize()).isZero();
+    }
+
+    private MatomoEvent event(String actionName, Map<Integer, String> dimensions) {
+        return new MatomoEvent(
+                "https://terminology.services.base4nfdi.de/api-gateway/search",
+                actionName,
+                "0123456789abcdef",
+                null, null, null, null, null, null,
+                0,
+                Instant.now(),
+                dimensions == null ? Map.of() : dimensions
+        );
+    }
+}

--- a/src/test/java/org/semantics/apigateway/tracking/MatomoTrackingInterceptorTest.java
+++ b/src/test/java/org/semantics/apigateway/tracking/MatomoTrackingInterceptorTest.java
@@ -1,0 +1,253 @@
+package org.semantics.apigateway.tracking;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.semantics.apigateway.service.auth.AuthService;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerMapping;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class MatomoTrackingInterceptorTest {
+
+    private static final String CLASSES_TEMPLATE = "/artefacts/{id}/resources/classes/{uri}";
+
+    private MatomoTracker tracker;
+    private MatomoProperties properties;
+    private AuthService authService;
+    private MatomoTrackingInterceptor interceptor;
+
+    @BeforeEach
+    void setUp() {
+        tracker = mock(MatomoTracker.class);
+        authService = mock(AuthService.class);
+        properties = new MatomoProperties();
+        properties.setVisitorIdSalt("test-salt");
+        interceptor = new MatomoTrackingInterceptor(tracker, properties, authService);
+    }
+
+    @Test
+    @DisplayName("tracks the uri template, never the resolved path carrying the ontology iri")
+    void tracksUriTemplateInsteadOfResolvedPath() {
+        String iri = "http://purl.obolibrary.org/obo/NCBITaxon_9606";
+        MockHttpServletRequest request = request("GET", "/artefacts/agroportal/resources/classes/" + iri, CLASSES_TEMPLATE);
+
+        MatomoEvent event = capture(request, new MockHttpServletResponse(), handler("classes"));
+
+        assertThat(event.url()).endsWith("/api-gateway" + CLASSES_TEMPLATE);
+        assertThat(event.url()).doesNotContain(iri);
+        assertThat(event.actionName()).isEqualTo("Artefacts / Data / GET " + CLASSES_TEMPLATE);
+    }
+
+    @Test
+    @DisplayName("derives the category from the springdoc tag of the controller")
+    void derivesCategoryFromTag() {
+        MockHttpServletRequest request = request("GET", "/search", "/search");
+
+        MatomoEvent event = capture(request, new MockHttpServletResponse(), handler("search"));
+
+        assertThat(event.actionName()).isEqualTo("Search / GET /search");
+    }
+
+    @Test
+    @DisplayName("falls back to the controller name when no tag is present")
+    void fallsBackToControllerName() {
+        MockHttpServletRequest request = request("GET", "/untagged", "/untagged");
+
+        MatomoEvent event = capture(request, new MockHttpServletResponse(), untaggedHandler("plain"));
+
+        assertThat(event.actionName()).isEqualTo("Untagged / GET /untagged");
+    }
+
+    @Test
+    @DisplayName("honours the MatomoTracking name override")
+    void honoursNameOverride() {
+        MockHttpServletRequest request = request("GET", "/renamed", "/renamed");
+
+        MatomoEvent event = capture(request, new MockHttpServletResponse(), handler("renamed"));
+
+        assertThat(event.actionName()).isEqualTo("Custom / Renamed action");
+    }
+
+    @Test
+    @DisplayName("skips handlers annotated with NoMatomoTracking")
+    void skipsOptedOutHandlers() {
+        MockHttpServletRequest request = request("GET", "/secret", "/secret");
+
+        interceptor.preHandle(request, new MockHttpServletResponse(), handler("secret"));
+        interceptor.afterCompletion(request, new MockHttpServletResponse(), handler("secret"), null);
+
+        verify(tracker, never()).track(any());
+    }
+
+    @Test
+    @DisplayName("skips paths matching the configured exclude patterns")
+    void skipsExcludedPaths() {
+        properties.setExcludePatterns(List.of("/status/**"));
+        MockHttpServletRequest request = request("GET", "/status/ping", "/status/ping");
+
+        interceptor.preHandle(request, new MockHttpServletResponse(), handler("search"));
+        interceptor.afterCompletion(request, new MockHttpServletResponse(), handler("search"), null);
+
+        verify(tracker, never()).track(any());
+    }
+
+    @Test
+    @DisplayName("skips non controller handlers such as static resources")
+    void skipsNonHandlerMethods() {
+        MockHttpServletRequest request = request("GET", "/favicon.ico", "/favicon.ico");
+
+        interceptor.afterCompletion(request, new MockHttpServletResponse(), new Object(), null);
+
+        verify(tracker, never()).track(any());
+    }
+
+    @Test
+    @DisplayName("records the configured custom dimensions only when an index is set")
+    void recordsConfiguredDimensions() {
+        properties.getDimensions().setDatabase(1);
+        properties.getDimensions().setStatus(3);
+        MockHttpServletRequest request = request("GET", "/search", "/search");
+        request.setParameter("database", "ols");
+        request.setParameter("targetDbSchema", "ols2");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        response.setStatus(200);
+
+        MatomoEvent event = capture(request, response, handler("search"));
+
+        assertThat(event.dimensions()).containsEntry(1, "ols").containsEntry(3, "200");
+        // targetDbSchema has no index configured, so it must not be sent.
+        assertThat(event.dimensions()).doesNotContainValue("ols2");
+    }
+
+    @Test
+    @DisplayName("reports the search term as a site search only when enabled")
+    void reportsSiteSearchWhenEnabled() {
+        MockHttpServletRequest request = request("GET", "/search", "/search");
+        request.setParameter("query", "plant");
+
+        assertThat(capture(request, new MockHttpServletResponse(), handler("search")).searchQuery()).isNull();
+
+        properties.setTrackSiteSearch(true);
+        assertThat(capture(request, new MockHttpServletResponse(), handler("search")).searchQuery()).isEqualTo("plant");
+    }
+
+    @Test
+    @DisplayName("produces a 16 character hexadecimal visitor id, stable per user and distinct across users")
+    void producesStableSixteenHexVisitorId() {
+        String first = interceptor.visitorId("alice", "10.0.0.1", "curl");
+        String second = interceptor.visitorId("alice", "10.0.0.9", "other-agent");
+        String other = interceptor.visitorId("bob", "10.0.0.1", "curl");
+
+        assertThat(first).hasSize(16).matches("[0-9a-f]{16}");
+        assertThat(first).isEqualTo(second).isNotEqualTo(other);
+    }
+
+    @Test
+    @DisplayName("does not send the username when the user is anonymous")
+    void doesNotSendAnonymousPrincipalAsUser() {
+        when(authService.getCurrentUsername()).thenReturn("anonymousUser");
+        MockHttpServletRequest request = request("GET", "/search", "/search");
+
+        assertThat(capture(request, new MockHttpServletResponse(), handler("search")).userId()).isNull();
+    }
+
+    @Test
+    @DisplayName("a tracking failure never propagates into the request")
+    void swallowsTrackingFailures() {
+        when(authService.getCurrentUsername()).thenThrow(new IllegalStateException("boom"));
+        MockHttpServletRequest request = request("GET", "/search", "/search");
+
+        interceptor.afterCompletion(request, new MockHttpServletResponse(), handler("search"), null);
+
+        verify(tracker, never()).track(any());
+    }
+
+    // -- helpers -----------------------------------------------------------------------------------------------
+
+    private MatomoEvent capture(MockHttpServletRequest request, MockHttpServletResponse response, HandlerMethod handler) {
+        MatomoTracker localTracker = mock(MatomoTracker.class);
+        MatomoTrackingInterceptor localInterceptor = new MatomoTrackingInterceptor(localTracker, properties, authService);
+        localInterceptor.preHandle(request, response, handler);
+        localInterceptor.afterCompletion(request, response, handler, null);
+
+        org.mockito.ArgumentCaptor<MatomoEvent> captor = org.mockito.ArgumentCaptor.forClass(MatomoEvent.class);
+        verify(localTracker).track(captor.capture());
+        return captor.getValue();
+    }
+
+    private MockHttpServletRequest request(String method, String path, String template) {
+        MockHttpServletRequest request = new MockHttpServletRequest(method, "/api-gateway" + path);
+        request.setContextPath("/api-gateway");
+        request.setServerName("example.org");
+        request.setScheme("https");
+        request.setServerPort(443);
+        request.setAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE, template);
+        return request;
+    }
+
+    private HandlerMethod handler(String methodName) {
+        return handlerMethod(new TestController(), methodName);
+    }
+
+    private HandlerMethod untaggedHandler(String methodName) {
+        return handlerMethod(new UntaggedController(), methodName);
+    }
+
+    private HandlerMethod handlerMethod(Object bean, String methodName) {
+        for (Method method : bean.getClass().getMethods()) {
+            if (method.getName().equals(methodName)) {
+                return new HandlerMethod(bean, method);
+            }
+        }
+        throw new IllegalArgumentException("No method " + methodName + " on " + bean.getClass());
+    }
+
+    @Tag(name = "Artefacts / Data")
+    static class TestController {
+
+        @Tag(name = "Search")
+        @GetMapping("/search")
+        public String search() {
+            return "";
+        }
+
+        @GetMapping("/artefacts/{id}/resources/classes/{uri}")
+        public String classes() {
+            return "";
+        }
+
+        @MatomoTracking(name = "Renamed action", category = "Custom")
+        @GetMapping("/renamed")
+        public String renamed() {
+            return "";
+        }
+
+        @NoMatomoTracking
+        @GetMapping("/secret")
+        public String secret() {
+            return "";
+        }
+    }
+
+    static class UntaggedController {
+
+        @GetMapping("/untagged")
+        public String plain() {
+            return "";
+        }
+    }
+}


### PR DESCRIPTION
Adds opt-in analytics tracking for all controller-backed endpoints, reporting page views (and optionally site search) to our Matomo instance via its bulk tracking API.

**How it works**
- MatomoTrackingInterceptor (HandlerInterceptor) is registered against all paths (/**) in MatomoWebConfig, so every controller-handled request is tracked automatically - no per-endpoint wiring needed for new endpoints
- Tracking runs in afterCompletion, after the response is fully sent, so duration and final status are known and a tracking failure can never affect the actual response
- The Matomo action name is built from the uri template (e.g. /artefacts/{id}) rather than the resolved path, making sure Matomo doesn’t create too many unique actions, even when the URL paths include ontology IRIs
- Visitor IDs are a salted SHA-256 hash: stable per username for authenticated users, and rotating daily (IP + UA + date) for anonymous ones. No raw personal information is sent as the identifier.
- Events are buffered in a bounded in-memory queue (MatomoTracker) and flushed on a schedule via Matomo's bulk endpoint, so tracking never blocks a request thread. Under sustained overload, events are dropped rather than backing up or blocking. 

Everything lives under the matomo.* prefix and is disabled by default (matomo.enabled=false), so it stays inactive until specified in the deployment. Configs: url, site-id, token-auth, track-client-ip (+ anonymization), track-user-id, track-site-search, custom dimension indices, batch size, flush interval, queue capacity, timeout, and exclude-patterns.