### PR TITLE
Add JsonPath-based response mappings to support SKOSMOS definitions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,9 @@ dependencies {
     // OIDC
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 
+    // JSON mapping
+    implementation 'com.jayway.jsonpath:json-path:3.0.0'
+
     // Tests
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'

--- a/src/main/java/org/semantics/apigateway/artefacts/metadata/ArtefactsService.java
+++ b/src/main/java/org/semantics/apigateway/artefacts/metadata/ArtefactsService.java
@@ -14,6 +14,7 @@ import org.semantics.apigateway.service.configuration.ConfigurationLoader;
 import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Service;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -98,7 +99,7 @@ public class ArtefactsService extends AbstractEndpointService {
         accessor = applyCollection(accessor, collection, endpoint);
 
         return accessor.get(params.getTimeout())
-                .thenApply(data -> this.transformApiResponses(data, endpoint))
+                .thenApply(data -> this.transformApiResponses(data, endpoint, new HashMap<>()))
                 .thenApply(transformedData -> flattenResponseList(transformedData, params, collection))
                 .thenApply(data -> filterOutArtefactsWithoutProperIri(data, params))
                 .thenApply(data -> filterOutByCollection(collection, data));

--- a/src/main/java/org/semantics/apigateway/artefacts/search/SearchService.java
+++ b/src/main/java/org/semantics/apigateway/artefacts/search/SearchService.java
@@ -59,9 +59,11 @@ public class SearchService extends AbstractEndpointService {
         accessor = initAccessor(database, endpoint, accessor);
         accessor = applyCollection(accessor, collection, endpoint);
         
+        HashMap<RequestParameter, String> requestParameters = new HashMap<>(Map.of(RequestParameter.query, query));
+        
         try {
-            return accessor.get(params.getTimeout(), new HashMap<>(Map.of(RequestParameter.query, query)))
-                    .thenApply(data -> this.transformApiResponses(data, endpoint))
+            return accessor.get(params.getTimeout(), requestParameters)
+                    .thenApply(data -> this.transformApiResponses(data, endpoint, requestParameters))
                     .thenApply(transformedData -> flattenResponseList(transformedData, params, collection))
                     .thenApply(data -> filterOutByCollection(collection, data))
                     .thenApply(data -> reIndexResults(query, data))
@@ -109,7 +111,7 @@ public class SearchService extends AbstractEndpointService {
         
         try {
             return accessor.get(params.getTimeout(), requestParameters)
-                    .thenApply(data -> this.transformApiResponses(data, endpoint))
+                    .thenApply(data -> this.transformApiResponses(data, endpoint, requestParameters))
                     .thenApply(transformedData -> flattenResponseList(transformedData, params, collection))
                     .thenApply(data -> filterOutByCollection(collection, data))
                     .thenApply(data -> reIndexResults(query, data))

--- a/src/main/java/org/semantics/apigateway/artefacts/tree/ArtefactsDataTreeService.java
+++ b/src/main/java/org/semantics/apigateway/artefacts/tree/ArtefactsDataTreeService.java
@@ -8,19 +8,13 @@ import org.semantics.apigateway.model.RDFResource;
 import org.semantics.apigateway.model.responses.AggregatedApiResponse;
 import org.semantics.apigateway.model.responses.AggregatedResourceBody;
 import org.semantics.apigateway.model.user.User;
-import org.semantics.apigateway.service.AbstractEndpointService;
-import org.semantics.apigateway.service.ApiAccessor;
-import org.semantics.apigateway.service.JsonLdTransform;
-import org.semantics.apigateway.service.ResponseTransformerService;
+import org.semantics.apigateway.service.*;
 import org.semantics.apigateway.service.configuration.ConfigurationLoader;
 import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Service;
 
 import java.net.URLEncoder;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 
 @Service
@@ -71,7 +65,7 @@ public class ArtefactsDataTreeService extends AbstractEndpointService {
 
         return findAll(artefactId, finalUri, endpoint, params, accessor, currentUser)
                 .thenApply(data -> databaseConfig.isOls() ? buildOlsTree(data, artefactId, resourceUri, params, currentUser) : data)
-                .thenApply(data -> databaseConfig.isOntoPortal() ? transformAllNestedChildren(data, databaseConfig, endpoint) : data);
+                .thenApply(data -> databaseConfig.isOntoPortal() ? transformAllNestedChildren(data, databaseConfig, endpoint, new HashMap<>()) : data);
     }
 
     private AggregatedApiResponse buildOlsTree(AggregatedApiResponse data, String artefactId, String resourceUri, CommonRequestParams params, User currentUser) {
@@ -92,17 +86,17 @@ public class ArtefactsDataTreeService extends AbstractEndpointService {
         return data;
     }
 
-    private AggregatedApiResponse transformAllNestedChildren(AggregatedApiResponse data, DatabaseConfig databaseConfig, String endpoint) {
+    private AggregatedApiResponse transformAllNestedChildren(AggregatedApiResponse data, DatabaseConfig databaseConfig, String endpoint, Map<RequestParameter, String> originalQueryParameters) {
         List<Map<String, Object>> items = data.getCollection();
         items.forEach(item -> {
-            List<Map<String, Object>> transformedChildren = transformNestedChildren((List<Map<String, Object>>) item.get("children"), databaseConfig, endpoint);
+            List<Map<String, Object>> transformedChildren = transformNestedChildren((List<Map<String, Object>>) item.get("children"), databaseConfig, endpoint, originalQueryParameters);
             item.put("children", transformedChildren);
         });
         data.setCollection(items);
         return data;
     }
 
-    private List<Map<String, Object>> transformNestedChildren(List<Map<String, Object>> children, DatabaseConfig databaseConfig, String endpoint) {
+    private List<Map<String, Object>> transformNestedChildren(List<Map<String, Object>> children, DatabaseConfig databaseConfig, String endpoint, Map<RequestParameter, String> originalQueryParameters) {
         if (children == null || children.isEmpty()) {
             return Collections.emptyList();
         }
@@ -110,13 +104,13 @@ public class ArtefactsDataTreeService extends AbstractEndpointService {
 
         children.forEach(child -> {
 
-            List<AggregatedResourceBody> transformedData = aggregatorTransformer.transformData(child, databaseConfig, endpoint);
+            List<AggregatedResourceBody> transformedData = aggregatorTransformer.transformData(child, databaseConfig, endpoint, originalQueryParameters);
             if (transformedData == null || transformedData.isEmpty()) {
                 return;
             }
 
             Map<String, Object> transformedChild = transformedData.get(0).toMap(false, true);
-            transformedChild.put("children", transformNestedChildren((List<Map<String, Object>>) transformedChild.get("children"), databaseConfig, endpoint));
+            transformedChild.put("children", transformNestedChildren((List<Map<String, Object>>) transformedChild.get("children"), databaseConfig, endpoint,  originalQueryParameters));
             transformedChildren.add(transformedChild);
         });
 

--- a/src/main/java/org/semantics/apigateway/model/responses/AggregatedResourceBody.java
+++ b/src/main/java/org/semantics/apigateway/model/responses/AggregatedResourceBody.java
@@ -9,6 +9,7 @@ import org.semantics.apigateway.config.DatabaseConfig;
 import org.semantics.apigateway.config.ResponseMapping;
 import org.semantics.apigateway.model.ContextUri;
 import org.semantics.apigateway.service.MappingTransformer;
+import org.semantics.apigateway.service.RequestParameter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,7 +93,7 @@ public abstract class AggregatedResourceBody {
         return allFields;
     }
 
-    public void fillWithItem(Map<String, Object> item, ResponseMapping mapping, boolean hardcodedValuesConfig) {
+    public void fillWithItem(Map<String, Object> item, ResponseMapping mapping, boolean hardcodedValuesConfig, Map<RequestParameter, String> originalQueryParameters) {
         AggregatedResourceBody target = this;
         // Create a reflection-based mapping of getter methods from ResponseMapping to their values
         Map<String, String> responseMappings = mapping.toMap();
@@ -121,16 +122,16 @@ public abstract class AggregatedResourceBody {
                 Class<?> fieldType = field.getType();
 
                 if (fieldType == String.class) {
-                    setStringProperty(item, mappingValue,
+                    setStringProperty(item, mappingValue, originalQueryParameters,
                             value -> setFieldValue(target, field, value));
                 } else if (fieldType == boolean.class || fieldType == Boolean.class) {
-                    setBooleanProperty(item, mappingValue,
+                    setBooleanProperty(item, mappingValue, originalQueryParameters,
                             value -> setFieldValue(target, field, value));
                 } else if (List.class.isAssignableFrom(fieldType)) {
-                    setListProperty(item, mappingValue,
+                    setListProperty(item, mappingValue, originalQueryParameters,
                             value -> setFieldValue(target, field, value));
                 } else if (Map.class.isAssignableFrom(fieldType)) {
-                    setMapProperty(item, mappingValue,
+                    setMapProperty(item, mappingValue, originalQueryParameters,
                             value -> setFieldValue(target, field, value));
                 }
             } catch (Exception e) {
@@ -154,7 +155,7 @@ public abstract class AggregatedResourceBody {
                        
                        if (mappingValue != null) {
                            
-                           Object value = MappingTransformer.itemValueGetter(item, mappingValue);
+                           Object value = MappingTransformer.itemValueGetter(item, mappingValue, originalQueryParameters);
                            
                            HashMap<String, Object> rootMap = new HashMap<>();
                            HashMap<String, Object> current = rootMap;
@@ -182,12 +183,12 @@ public abstract class AggregatedResourceBody {
     public static <T extends AggregatedResourceBody> T fromMap(
             Map<String, Object> item,
             DatabaseConfig config,
-            String endpoint, T object) throws RuntimeException {
+            String endpoint, Map<RequestParameter, String> originalQueryParameters, T object) throws RuntimeException {
         ResponseMapping responseMapping = config.getResponseMapping(endpoint);
         boolean localDataValues = config.getUrl(endpoint).endsWith("localData");
 
         object.setOriginalBody(item);
-        object.fillWithItem(item, responseMapping, localDataValues);
+        object.fillWithItem(item, responseMapping, localDataValues,  originalQueryParameters);
         object.setDefaultValues(config);
 
 
@@ -280,12 +281,12 @@ public abstract class AggregatedResourceBody {
             return  field.get(this);
         }
     }
-    private void setStringProperty(Map<String, Object> item, String key, Consumer<String> setter) {
+    private void setStringProperty(Map<String, Object> item, String key, Map<RequestParameter, String> originalQueryParameters, Consumer<String> setter) {
         Object value;
         if (localDataValues) {
             value = key;
         } else {
-            value = MappingTransformer.itemValueGetter(item, key);
+            value = MappingTransformer.itemValueGetter(item, key, originalQueryParameters);
 
         }
         Optional.ofNullable(value)
@@ -298,21 +299,26 @@ public abstract class AggregatedResourceBody {
                 }).map(Object::toString).ifPresent(setter);
     }
 
-    private void setBooleanProperty(Map<String, Object> item, String key, Consumer<Boolean> setter) {
-        Object value = MappingTransformer.itemValueGetter(item, key);
+    private void setBooleanProperty(Map<String, Object> item, String key, Map<RequestParameter, String> originalQueryParameters, Consumer<Boolean> setter) {
+        Object value = MappingTransformer.itemValueGetter(item, key, originalQueryParameters);
         if (value != null) {
-            setter.accept(Boolean.parseBoolean(value.toString()));
+            if (value instanceof List<?> list) {
+                setter.accept(!list.isEmpty());
+            } else {
+                // For JsonPath mapping keys (always returns a list, we use it for checking whether there are elements)
+                setter.accept(Boolean.parseBoolean(value.toString()));
+            }
         } else {
             setter.accept(false);
         }
     }
 
-    private void setListProperty(Map<String, Object> item, String key, Consumer<List<Object>> setter) {
+    private void setListProperty(Map<String, Object> item, String key, Map<RequestParameter, String> originalQueryParameters, Consumer<List<Object>> setter) {
         Object value;
         if (localDataValues) {
             value = key != null ? List.of(key.split(";")) : Collections.emptyList();
         } else {
-            value = MappingTransformer.itemValueGetter(item, key);
+            value = MappingTransformer.itemValueGetter(item, key, originalQueryParameters);
         }
         List<Object> list = Collections.emptyList();
         if (value instanceof List) {
@@ -323,8 +329,8 @@ public abstract class AggregatedResourceBody {
         setter.accept(list);
     }
     
-    private void setMapProperty(Map<String, Object> item, String key, Consumer<Map<String, Object>> setter) {
-        Object value = MappingTransformer.itemValueGetter(item, key);
+    private void setMapProperty(Map<String, Object> item, String key, Map<RequestParameter, String> originalQueryParameters, Consumer<Map<String, Object>> setter) {
+        Object value = MappingTransformer.itemValueGetter(item, key, originalQueryParameters);
         if (!(value instanceof Map)) {
             setter.accept(Collections.emptyMap());
         } else {

--- a/src/main/java/org/semantics/apigateway/service/AbstractEndpointService.java
+++ b/src/main/java/org/semantics/apigateway/service/AbstractEndpointService.java
@@ -153,19 +153,19 @@ public abstract class AbstractEndpointService {
     }
 
     protected List<TransformedApiResponse> transformApiResponses(Map<String, ApiResponse> apiData, String
-            endpoint) {
-        return transformApiResponses(apiData, endpoint, false);
+            endpoint, Map<RequestParameter, String> originalQueryParameters) {
+        return transformApiResponses(apiData, endpoint, false, originalQueryParameters);
     }
 
     protected List<TransformedApiResponse> transformApiResponses(Map<String, ApiResponse> apiData, String
-            endpoint, boolean paginate) {
+            endpoint, boolean paginate, Map<RequestParameter, String> originalQueryParameters) {
         return apiData.entrySet().stream()
-                .map(x -> this.transformSingleApiResponse(x, endpoint, paginate))
+                .map(x -> this.transformSingleApiResponse(x, endpoint, paginate, originalQueryParameters))
                 .collect(Collectors.toList());
     }
 
     protected TransformedApiResponse transformSingleApiResponse(Map.Entry<String, ApiResponse> entry, String
-            endpoint, boolean paginate) {
+            endpoint, boolean paginate, Map<RequestParameter, String> originalQueryParameters) {
         String url = entry.getKey();
         ApiResponse results = entry.getValue();
         DatabaseConfig config = null;
@@ -175,7 +175,7 @@ public abstract class AbstractEndpointService {
             logger.error("Error getting config for URL: {}", url, e);
         }
 
-        return aggregatorTransformer.transformResponse(results, config, endpoint, paginate);
+        return aggregatorTransformer.transformResponse(results, config, endpoint, paginate, originalQueryParameters);
     }
 
     protected AggregatedApiResponse singleResponse(TransformedApiResponse transformedResponse, CommonRequestParams
@@ -416,7 +416,7 @@ public abstract class AbstractEndpointService {
         apiParameters.put(RequestParameter.page, "" + page);
 
         return accessor.get(params.getTimeout(), apiParameters)
-                .thenApply(data -> this.transformApiResponses(data, endpoint, true))
+                .thenApply(data -> this.transformApiResponses(data, endpoint, true, apiParameters))
                 .thenApply(data -> selectResultsByDatabase(data, database))
                 .thenApply(x -> paginate(x, params, page))
                 .thenApply(x -> transformJsonLd(x, params));
@@ -449,7 +449,7 @@ public abstract class AbstractEndpointService {
         Map<RequestParameter, String> requestParameters = getRequestIds(accessor, artefactId, resourceUri);
 
         return accessor.get(params.getTimeout(), requestParameters)
-                .thenApply(data -> this.transformApiResponses(data, endpoint))
+                .thenApply(data -> this.transformApiResponses(data, endpoint, requestParameters))
                 .thenApply(data -> selectResultsByDatabase(data, database))
                 .thenApply(data -> listResponse(data, params))
                 .thenApply(x -> transformJsonLd(x, params));
@@ -474,26 +474,26 @@ public abstract class AbstractEndpointService {
         return result;
     }
 
-    protected CompletableFuture<AggregatedApiResponse> findUriBase(String id, String uri, String endpoint, CommonRequestParams params, ApiAccessor
+    protected CompletableFuture<AggregatedApiResponse> findUriBase(String id, String resourceUri, String endpoint, CommonRequestParams params, ApiAccessor
             accessor,  User currentUser) {
         String database = params.getDatabase();
         accessor = initAccessor(database, endpoint, accessor);
         accessor = applyCollection(accessor, collectionService.getCurrentUserCollection(params.getCollectionId(), currentUser), endpoint);
-        Map<RequestParameter, String> requestParameters = getRequestIds(accessor, id, uri);
+        Map<RequestParameter, String> requestParameters = getRequestIds(accessor, id, resourceUri);
 
         return accessor.get(params.getTimeout(), requestParameters)
-                .thenApply(data -> this.transformApiResponses(data, endpoint))
+                .thenApply(data -> this.transformApiResponses(data, endpoint, requestParameters))
                 .thenApply(x -> filterById(x, requestParameters))
                 .thenApply(data -> selectResultsByDatabase(data, database))
                 .thenApply(x -> singleResponse(x, params))
                 .thenApply(x -> transformJsonLd(x, params));
     }
 
-    protected AggregatedApiResponse findUri(String id, String uri, String endpoint, CommonRequestParams params, ApiAccessor
+    protected AggregatedApiResponse findUri(String id, String resourceUri, String endpoint, CommonRequestParams params, ApiAccessor
             accessor,  User currentUser) {
         TargetDbSchema targetDbSchema = params.getTargetDbSchema();
         try {
-            return findUriBase(id, uri, endpoint, params, accessor, currentUser)
+            return findUriBase(id, resourceUri, endpoint, params, accessor, currentUser)
                     .thenApply(data -> transformForTargetDbSchema(data, targetDbSchema, endpoint, false))
                     .get();
         } catch (InterruptedException | ExecutionException e) {

--- a/src/main/java/org/semantics/apigateway/service/AbstractEndpointService.java
+++ b/src/main/java/org/semantics/apigateway/service/AbstractEndpointService.java
@@ -153,19 +153,19 @@ public abstract class AbstractEndpointService {
     }
 
     protected List<TransformedApiResponse> transformApiResponses(Map<String, ApiResponse> apiData, String
-            endpoint) {
-        return transformApiResponses(apiData, endpoint, false);
+            endpoint, Map<RequestParameter, String> originalQueryParameters) {
+        return transformApiResponses(apiData, endpoint, false, originalQueryParameters);
     }
 
     protected List<TransformedApiResponse> transformApiResponses(Map<String, ApiResponse> apiData, String
-            endpoint, boolean paginate) {
+            endpoint, boolean paginate, Map<RequestParameter, String> originalQueryParameters) {
         return apiData.entrySet().stream()
-                .map(x -> this.transformSingleApiResponse(x, endpoint, paginate))
+                .map(x -> this.transformSingleApiResponse(x, endpoint, paginate, originalQueryParameters))
                 .collect(Collectors.toList());
     }
 
     protected TransformedApiResponse transformSingleApiResponse(Map.Entry<String, ApiResponse> entry, String
-            endpoint, boolean paginate) {
+            endpoint, boolean paginate, Map<RequestParameter, String> originalQueryParameters) {
         String url = entry.getKey();
         ApiResponse results = entry.getValue();
         DatabaseConfig config = null;
@@ -175,7 +175,7 @@ public abstract class AbstractEndpointService {
             logger.error("Error getting config for URL: {}", url, e);
         }
 
-        return aggregatorTransformer.transformResponse(results, config, endpoint, paginate);
+        return aggregatorTransformer.transformResponse(results, config, endpoint, paginate, originalQueryParameters);
     }
 
     protected AggregatedApiResponse singleResponse(TransformedApiResponse transformedResponse, CommonRequestParams
@@ -418,7 +418,7 @@ public abstract class AbstractEndpointService {
         apiParameters.put(RequestParameter.page, "" + page);
 
         return accessor.get(params.getTimeout(), apiParameters)
-                .thenApply(data -> this.transformApiResponses(data, endpoint, true))
+                .thenApply(data -> this.transformApiResponses(data, endpoint, true, apiParameters))
                 .thenApply(data -> selectResultsByDatabase(data, database))
                 .thenApply(x -> paginate(x, params, page))
                 .thenApply(x -> transformJsonLd(x, params))
@@ -438,7 +438,7 @@ public abstract class AbstractEndpointService {
         Map<RequestParameter, String> requestParameters = getRequestIds(accessor, artefactId, resourceUri);
 
         return accessor.get(params.getTimeout(), requestParameters)
-                .thenApply(data -> this.transformApiResponses(data, endpoint))
+                .thenApply(data -> this.transformApiResponses(data, endpoint, requestParameters))
                 .thenApply(data -> selectResultsByDatabase(data, database))
                 .thenApply(data -> listResponse(data, params))
                 .thenApply(x -> transformJsonLd(x, params));
@@ -472,7 +472,7 @@ public abstract class AbstractEndpointService {
         Map<RequestParameter, String> requestParameters = getRequestIds(accessor, id, resourceUri);
         try {
             return accessor.get(params.getTimeout(), requestParameters)
-                    .thenApply(data -> this.transformApiResponses(data, endpoint))
+                    .thenApply(data -> this.transformApiResponses(data, endpoint, requestParameters))
                     .thenApply(x -> filterById(x, requestParameters))
                     .thenApply(data -> selectResultsByDatabase(data, database))
                     .thenApply(x -> singleResponse(x, params))

--- a/src/main/java/org/semantics/apigateway/service/MappingTransformer.java
+++ b/src/main/java/org/semantics/apigateway/service/MappingTransformer.java
@@ -1,6 +1,13 @@
 package org.semantics.apigateway.service;
 
+import com.jayway.jsonpath.JsonPath;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -33,6 +40,11 @@ import java.util.stream.Collectors;
  * </pre>
  */
 public class MappingTransformer {
+    
+    private static final Logger logger = LoggerFactory.getLogger(MappingTransformer.class);
+    
+    private final static Pattern pathParamPattern = Pattern.compile("\\{(.*?)}");
+    
     /**
      * Retrieves a value from a nested map or list structure based on a flexible key path.
      *
@@ -40,10 +52,26 @@ public class MappingTransformer {
      * data.put("user", Map.of("name", "John Doe"));
      * Object value = itemValueGetter(data, "user->name"); // Returns "John Doe"
      */
-    public static Object itemValueGetter(Map<String, Object> item, String key) {
-        if (key == null) {
+    public static Object itemValueGetter(Map<String, Object> item, String keyWithPlaceholders, Map<RequestParameter, String> originalQueryParameters) {
+        if (keyWithPlaceholders == null) {
             return null;
         }
+        
+        String key = pathParamPattern.matcher(keyWithPlaceholders).replaceAll(match -> {
+            String paramKey = match.group(1);
+            String paramValue = originalQueryParameters.get(RequestParameter.valueOf(paramKey));
+            if (paramValue == null) {
+                logger.error("No value for path parameter '{}' for mapping key {}", paramKey, keyWithPlaceholders);
+                return "";
+            }
+            return URLDecoder.decode(paramValue, StandardCharsets.UTF_8);
+        });
+        
+        if (key.startsWith("$")) {
+            // This is a JsonPath key
+            return JsonPath.read(item, key);
+        }
+        
         String[] options = key.split("\\|");
         // Use findFirst to return the first non-null value found
         return Arrays.stream(options)
@@ -75,14 +103,14 @@ public class MappingTransformer {
                 .findFirst()
                 .orElse(null);
     }
-
-    /**
-     * Retrieves a value from a list based on an index or key.
-     *
-     * @param key  The index or key to retrieve
-     * @param list The source list
-     * @return The value at the specified index or null
-     */
+    
+        /**
+         * Retrieves a value from a list based on an index or key.
+         *
+         * @param key  The index or key to retrieve
+         * @param list The source list
+         * @return The value at the specified index or null
+         */
     public static List<String> listItemValueGetter(String key, Object list) {
         if (!(list instanceof List)) {
             return null;
@@ -199,12 +227,13 @@ public class MappingTransformer {
      */
     public static Map<String, Object> transform(
             Map<String, Object> source,
-            Map<String, String> mappings
+            Map<String, String> mappings,
+            Map<RequestParameter, String> originalQueryParameters
     ) {
         return mappings.entrySet().stream()
                 .collect(Collectors.toMap(
                         Map.Entry::getKey,
-                        entry -> itemValueGetter(source, entry.getValue()),
+                        entry -> itemValueGetter(source, entry.getValue(), originalQueryParameters),
                         (v1, v2) -> v1,  // In case of duplicate keys, keep first value
                         HashMap::new
                 ));

--- a/src/main/java/org/semantics/apigateway/service/ResponseAggregatorService.java
+++ b/src/main/java/org/semantics/apigateway/service/ResponseAggregatorService.java
@@ -23,7 +23,7 @@ public class ResponseAggregatorService {
         this.clazz = clazz;
     }
 
-    public TransformedApiResponse transformResponse(ApiResponse response, DatabaseConfig config, String endpoint, boolean paginate) {
+    public TransformedApiResponse transformResponse(ApiResponse response, DatabaseConfig config, String endpoint, boolean paginate, Map<RequestParameter, String> originalQueryParameters) {
         TransformedApiResponse newResponse = new TransformedApiResponse();
         newResponse.setOriginalResponse(response);
 
@@ -42,13 +42,13 @@ public class ResponseAggregatorService {
         String paginationKey = config.getResponseMapping(endpoint).getPage();
         String totalCount = config.getResponseMapping(endpoint).getTotalCount();
 
-        if(getData(response.getResponseBody(), paginationKey).isPresent()) {
+        if(getData(response.getResponseBody(), paginationKey, originalQueryParameters).isPresent()) {
           try {
-            newResponse.setPage((int)Double.parseDouble(getData(response.getResponseBody(), paginationKey).get()));
+            newResponse.setPage((int)Double.parseDouble(getData(response.getResponseBody(), paginationKey, originalQueryParameters).get()));
           } catch (NumberFormatException e) {
           }
           try {
-            newResponse.setTotalCollections((long)Double.parseDouble(getData(response.getResponseBody(), totalCount).orElse("0")));
+            newResponse.setTotalCollections((long)Double.parseDouble(getData(response.getResponseBody(), totalCount, originalQueryParameters).orElse("0")));
           } catch (NumberFormatException e) {
           }
           newResponse.setPaginate(true);
@@ -59,7 +59,7 @@ public class ResponseAggregatorService {
             return newResponse;
         }
 
-        List<AggregatedResourceBody> result = transformData(nestedData, config, endpoint);
+        List<AggregatedResourceBody> result = transformData(nestedData, config, endpoint, originalQueryParameters);
         newResponse.setCollection(result);
 
         logger.info("Transformed response: {} from  {}", result.size(), config.getName());
@@ -77,14 +77,14 @@ public class ResponseAggregatorService {
     }
 
     // Transform nested data into a list of AggregatedResourceBody
-    public List<AggregatedResourceBody> transformData(Object nestedData, DatabaseConfig config, String endpoint) {
+    public List<AggregatedResourceBody> transformData(Object nestedData, DatabaseConfig config, String endpoint, Map<RequestParameter, String> originalQueryParameters) {
         List<AggregatedResourceBody> result = new ArrayList<>();
         if (nestedData instanceof List && !((List) nestedData).isEmpty()) {
-            processList((List<?>) nestedData, result, config, endpoint);
+            processList((List<?>) nestedData, result, config, endpoint, originalQueryParameters);
         } else if (nestedData instanceof Map && !((Map) nestedData).isEmpty()) {
             Object docs = extractDocsFromMap((Map<?, ?>) nestedData, config, endpoint);
             if(docs != null){
-                processDocs(docs, result, config, endpoint);
+                processDocs(docs, result, config, endpoint, originalQueryParameters);
             }
         }
 
@@ -98,33 +98,33 @@ public class ResponseAggregatorService {
     }
 
     // Process the documents whether they are a List or single item
-    private void processDocs(Object docs, List<AggregatedResourceBody> result, DatabaseConfig config, String endpoint) {
+    private void processDocs(Object docs, List<AggregatedResourceBody> result, DatabaseConfig config, String endpoint, Map<RequestParameter, String> originalQueryParameters) {
         if (docs instanceof List) {
-            processList((List<?>) docs, result, config, endpoint);
+            processList((List<?>) docs, result, config, endpoint, originalQueryParameters);
         } else if (docs instanceof Map) {
             Map<?, ?> docsMap = (Map<?, ?>) docs;
             if(docsMap.containsKey("collection") && docsMap.size() == 1){
-                processList((List<?>) docsMap.get("collection"), result, config, endpoint);
+                processList((List<?>) docsMap.get("collection"), result, config, endpoint, originalQueryParameters);
             } else {
-                addNewItem(docs, result, config, endpoint);
+                addNewItem(docs, result, config, endpoint, originalQueryParameters);
             }
         } else {
             logger.error("Unexpected document type: {}. Expected List or Map.", docs.getClass().getSimpleName());
         }
     }
 
-    private void addNewItem(Object docs, List<AggregatedResourceBody> result, DatabaseConfig config, String endpoint) {
-        AggregatedResourceBody newItem = processItem((Map<String, Object>) docs, config, endpoint);
+    private void addNewItem(Object docs, List<AggregatedResourceBody> result, DatabaseConfig config, String endpoint, Map<RequestParameter, String> originalQueryParameters) {
+        AggregatedResourceBody newItem = processItem((Map<String, Object>) docs, config, endpoint, originalQueryParameters);
         if (newItem != null) {
             result.add(newItem);
         }
     }
 
     // Process list of items and add valid processed items to the result list
-    private void processList(List<?> dataList, List<AggregatedResourceBody> result, DatabaseConfig config, String endpoint) {
+    private void processList(List<?> dataList, List<AggregatedResourceBody> result, DatabaseConfig config, String endpoint, Map<RequestParameter, String> originalQueryParameters) {
         for (Object item : dataList) {
             if (item instanceof Map) {
-                addNewItem(item, result, config, endpoint);
+                addNewItem(item, result, config, endpoint, originalQueryParameters);
             } else {
                 logger.warn("Skipping non-Map item: {}", item);
             }
@@ -132,9 +132,9 @@ public class ResponseAggregatorService {
     }
 
     // Process individual map items into AggregatedResourceBody
-    private AggregatedResourceBody processItem(Map<String, Object> item, DatabaseConfig config, String endpoint) {
+    private AggregatedResourceBody processItem(Map<String, Object> item, DatabaseConfig config, String endpoint, Map<RequestParameter, String> originalQueryParameters) {
         try {
-            return AggregatedResourceBody.fromMap(item, config, endpoint, getClazz().getDeclaredConstructor().newInstance());
+            return AggregatedResourceBody.fromMap(item, config, endpoint, originalQueryParameters, getClazz().getDeclaredConstructor().newInstance());
         } catch (Exception e) {
             e.printStackTrace();
             logger.error("Error processing item: {}", e.getMessage(), e);
@@ -152,9 +152,9 @@ public class ResponseAggregatorService {
         return config.getResponseMapping(endpoint).getKey();
     }
 
-    private Optional<String> getData(Map<String, Object> responseBody, String key) {
+    private Optional<String> getData(Map<String, Object> responseBody, String key, Map<RequestParameter, String> originalQueryParameters) {
         Optional<String> result = Optional.empty();
-        Object value = MappingTransformer.itemValueGetter(responseBody, key);
+        Object value = MappingTransformer.itemValueGetter(responseBody, key,  originalQueryParameters);
         if (value != null) {
             result = Optional.of(value.toString());
         }

--- a/src/main/resources/backend_types/skosmos.yml
+++ b/src/main/resources/backend_types/skosmos.yml
@@ -13,6 +13,14 @@ models:
     ontology: vocab
     type: type
     hasChildren: hasDirectChildren
+  graph: &graph
+    label: "$.graph[?(@.uri=='{resourceUri}')].prefLabel[?(@.lang=='en')].value"
+    iri: "$.graph[?(@.uri=='{resourceUri}')].uri"
+    synonyms: "$.graph[?(@.uri=='{resourceUri}')].altLabel[?(@.lang=='en')].value"
+    descriptions: "$.graph[?(@.uri in $.graph[?(@.uri=='{resourceUri}')]['skos:definition'][*].uri)]['http://www.w3.org/1999/02/22-rdf-syntax-ns#value'][?(@.lang=='en')].value"
+    ontologyIri: "$.graph[?(@.uri=='{resourceUri}')].inScheme.uri"
+    type: "$.graph[?(@.uri=='{resourceUri}')].type"
+    hasChildren: "$.graph[?(@.uri=='{resourceUri}')].narrower"
 
 endpoints:
   search:
@@ -50,17 +58,17 @@ endpoints:
       <<: *term
 
   concept_details:
-    path: /{artefact}/label
+    path: /{artefact}/data?format=application%2Fld%2Bjson
     caseInsensitive: false
     parameters:
       artefact:
-        name: acronym
+        name: vocid
         type: string
       resourceUri:
         name: uri
         type: string
     responseMapping:
-      <<: *term
+      <<: *graph
 
   resource_details:
     path: /{artefact}

--- a/src/main/resources/backend_types/skosmos.yml
+++ b/src/main/resources/backend_types/skosmos.yml
@@ -13,6 +13,14 @@ models:
     ontology: vocab
     type: type
     hasChildren: hasDirectChildren
+  graph: &graph
+    label: "$.graph[?(@.uri=='{resourceUri}')].prefLabel[?(@.lang=='en')].value"
+    iri: "$.graph[?(@.uri=='{resourceUri}')].uri"
+    synonyms: "$.graph[?(@.uri=='{resourceUri}')].altLabel[?(@.lang=='en')].value"
+    descriptions: "$.graph[?(@.uri in $.graph[?(@.uri=='{resourceUri}')]['skos:definition'][*].uri)]['http://www.w3.org/1999/02/22-rdf-syntax-ns#value'][?(@.lang=='en')].value"
+    ontologyIri: "$.graph[?(@.uri=='{resourceUri}')].inScheme.uri"
+    type: "$.graph[?(@.uri=='{resourceUri}')].type"
+    hasChildren: "$.graph[?(@.uri=='{resourceUri}')].narrower"
 
 endpoints:
   search:
@@ -49,16 +57,17 @@ endpoints:
       <<: *term
 
   concept_details:
-    path: /{artefact}/label
+    path: /{artefact}/data?format=application%2Fld%2Bjson
+    caseInsensitive: false
     parameters:
       artefact:
-        name: acronym
+        name: vocid
         type: string
       resourceUri:
         name: uri
         type: string
     responseMapping:
-      <<: *term
+      <<: *graph
 
   resource_details:
     path: /{artefact}

--- a/src/test/java/org/semantics/apigateway/ArtefactDataServiceTest.java
+++ b/src/test/java/org/semantics/apigateway/ArtefactDataServiceTest.java
@@ -32,12 +32,12 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
         mockApiAccessor("artefact_term", artefactsService.getAccessor());
         CommonRequestParams params = new CommonRequestParams();
         params.setDatabase("skosmos");
-        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefactTerm("AGROVOC", "http://aims.fao.org/aos/agrovoc/c_330834", params, apiAccessor, null);
+        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefactTerm("agrovoc", "http://aims.fao.org/aos/agrovoc/c_330834", params, apiAccessor, null);
         assertMapEquality(response, createSkosmosAgrovocTerm());
 
         params = new CommonRequestParams();
         params.setDatabase("ontoportal");
-        response = (AggregatedApiResponse) artefactsService.getArtefactTerm("AGROVOC", "http://aims.fao.org/aos/agrovoc/c_330834", params, apiAccessor, null);
+        response = (AggregatedApiResponse) artefactsService.getArtefactTerm("agrovoc", "http://aims.fao.org/aos/agrovoc/c_330834", params, apiAccessor, null);
         assertMapEquality(response, createOntoPortalAgrovocTermFixture());
 
         params = new CommonRequestParams();
@@ -327,13 +327,13 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
         fixture.put("source", "https://agrovoc.fao.org/browse/rest/v1");
         fixture.put("source_name", "agrovoc");
         fixture.put("synonyms", Collections.emptyList());
-        fixture.put("descriptions", Collections.emptyList());
+        fixture.put("descriptions", List.of("A sequence of actions organized towards a specific goal."));
         fixture.put("created", null);
         fixture.put("modified", null);
         fixture.put("obsolete", false);
         fixture.put("source_url", null);
         fixture.put("version", null);
-        fixture.put("ontology_iri", "https://agrovoc.fao.org/browse/rest/v1");
+        fixture.put("ontology_iri", "http://aims.fao.org/aos/agrovoc");
         fixture.put("short_form", "c_330834");
         fixture.put("ontology", "agrovoc");
         return fixture;

--- a/src/test/java/org/semantics/apigateway/ArtefactDataServiceTest.java
+++ b/src/test/java/org/semantics/apigateway/ArtefactDataServiceTest.java
@@ -32,12 +32,12 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
         mockApiAccessor("artefact_term", artefactsService.getAccessor());
         CommonRequestParams params = new CommonRequestParams();
         params.setDatabase("skosmos");
-        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefactTerm("AGROVOC", "http://aims.fao.org/aos/agrovoc/c_330834", params, apiAccessor, null);
+        AggregatedApiResponse response = (AggregatedApiResponse) artefactsService.getArtefactTerm("agrovoc", "http://aims.fao.org/aos/agrovoc/c_330834", params, apiAccessor, null);
         assertMapEquality(response, createSkosmosAgrovocTerm());
 
         params = new CommonRequestParams();
         params.setDatabase("ontoportal");
-        response = (AggregatedApiResponse) artefactsService.getArtefactTerm("AGROVOC", "http://aims.fao.org/aos/agrovoc/c_330834", params, apiAccessor, null);
+        response = (AggregatedApiResponse) artefactsService.getArtefactTerm("agrovoc", "http://aims.fao.org/aos/agrovoc/c_330834", params, apiAccessor, null);
         assertMapEquality(response, createOntoPortalAgrovocTermFixture());
 
         params = new CommonRequestParams();
@@ -306,13 +306,13 @@ public class ArtefactDataServiceTest extends ApplicationTestAbstract {
         fixture.put("source", "https://agrovoc.fao.org/browse/rest/v1");
         fixture.put("source_name", "agrovoc");
         fixture.put("synonyms", Collections.emptyList());
-        fixture.put("descriptions", Collections.emptyList());
+        fixture.put("descriptions", List.of("A sequence of actions organized towards a specific goal."));
         fixture.put("created", null);
         fixture.put("modified", null);
         fixture.put("obsolete", false);
         fixture.put("source_url", null);
         fixture.put("version", null);
-        fixture.put("ontology_iri", "https://agrovoc.fao.org/browse/rest/v1");
+        fixture.put("ontology_iri", "http://aims.fao.org/aos/agrovoc");
         fixture.put("short_form", "c_330834");
         fixture.put("ontology", "agrovoc");
         return fixture;

--- a/src/test/resources/mocks/artefact_term/agrovoc.json
+++ b/src/test/resources/mocks/artefact_term/agrovoc.json
@@ -1,13 +1,12983 @@
 {
   "@context": {
-    "skos": "http:\/\/www.w3.org\/2004\/02\/skos\/core#",
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "isothes": "http://purl.org/iso25964/skos-thes#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "dct": "http://purl.org/dc/terms/",
+    "dc11": "http://purl.org/dc/elements/1.1/",
     "uri": "@id",
     "type": "@type",
+    "lang": "@language",
+    "value": "@value",
+    "graph": "@graph",
+    "label": "rdfs:label",
     "prefLabel": "skos:prefLabel",
     "altLabel": "skos:altLabel",
     "hiddenLabel": "skos:hiddenLabel",
-    "@language": "en"
+    "broader": "skos:broader",
+    "narrower": "skos:narrower",
+    "related": "skos:related",
+    "inScheme": "skos:inScheme",
+    "exactMatch": "skos:exactMatch",
+    "closeMatch": "skos:closeMatch",
+    "broadMatch": "skos:broadMatch",
+    "narrowMatch": "skos:narrowMatch",
+    "relatedMatch": "skos:relatedMatch"
   },
-  "uri": "http:\/\/aims.fao.org\/aos\/agrovoc\/c_330834",
-  "prefLabel": "activities"
+  "graph": [
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc",
+      "type": "skos:ConceptScheme",
+      "skos:hasTopConcept": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": {
+        "lang": "en",
+        "value": "AGROVOC"
+      }
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_10179",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "sw",
+          "value": "uzuiaji ukatili"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "prevenção da crueldade"
+        },
+        {
+          "lang": "ar",
+          "value": "منع القسوة"
+        },
+        {
+          "lang": "uk",
+          "value": "захист тварин від жорстокого поводження"
+        },
+        {
+          "lang": "tr",
+          "value": "hayvanlara zulmün önlenmesi"
+        },
+        {
+          "lang": "zh",
+          "value": "防止虐待"
+        },
+        {
+          "lang": "th",
+          "value": "การป้องกันความดุร้าย"
+        },
+        {
+          "lang": "sk",
+          "value": "prevencia krutosti"
+        },
+        {
+          "lang": "ru",
+          "value": "защита животных от жестокого обращения"
+        },
+        {
+          "lang": "cs",
+          "value": "prevence hrubého zacházení"
+        },
+        {
+          "lang": "de",
+          "value": "Verhütung von Grausamkeit"
+        },
+        {
+          "lang": "en",
+          "value": "cruelty prevention"
+        },
+        {
+          "lang": "es",
+          "value": "Prevención de la crueldad"
+        },
+        {
+          "lang": "fa",
+          "value": "پيشگيري از آزار (جانوران)"
+        },
+        {
+          "lang": "fr",
+          "value": "prévention de la cruauté"
+        },
+        {
+          "lang": "hi",
+          "value": "क्रूरता बचाव"
+        },
+        {
+          "lang": "hu",
+          "value": "állatok elleni kegyetlenség megelőzése"
+        },
+        {
+          "lang": "it",
+          "value": "Prevenzione della crudeltà"
+        },
+        {
+          "lang": "ja",
+          "value": "虐待防止"
+        },
+        {
+          "lang": "ko",
+          "value": "동물학대방지"
+        },
+        {
+          "lang": "lo",
+          "value": "ການປ້ອງກັນສັດຮ້າຍ"
+        },
+        {
+          "lang": "pl",
+          "value": "Zapobieganie okrucieństwu wobec zwierząt"
+        },
+        {
+          "lang": "pt",
+          "value": "prevenção da crueldade"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_10397",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "sr",
+          "value": "дезинфекција"
+        },
+        {
+          "lang": "be",
+          "value": "дэзынфекцыя"
+        },
+        {
+          "lang": "vi",
+          "value": "kiểm soát vi khuẩn"
+        },
+        {
+          "lang": "ka",
+          "value": "დეზინფექცია"
+        },
+        {
+          "lang": "sw",
+          "value": "kuua viini"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "desinfecção"
+        },
+        {
+          "lang": "ro",
+          "value": "dezinfecție"
+        },
+        {
+          "lang": "sv",
+          "value": "desinfektion"
+        },
+        {
+          "lang": "te",
+          "value": "శిలీంద్ర నియంత్రణ(సంక్రమణ నిరోధము)"
+        },
+        {
+          "lang": "uk",
+          "value": "дезинфікування"
+        },
+        {
+          "lang": "tr",
+          "value": "dezenfeksiyon"
+        },
+        {
+          "lang": "zh",
+          "value": "消毒"
+        },
+        {
+          "lang": "th",
+          "value": "การฆ่าเชื้อ"
+        },
+        {
+          "lang": "sk",
+          "value": "dezinfekcia"
+        },
+        {
+          "lang": "ru",
+          "value": "дезинфекция"
+        },
+        {
+          "lang": "pt",
+          "value": "desinfecção"
+        },
+        {
+          "lang": "ar",
+          "value": "تطهير"
+        },
+        {
+          "lang": "cs",
+          "value": "dezinfekce"
+        },
+        {
+          "lang": "de",
+          "value": "Desinfektion"
+        },
+        {
+          "lang": "en",
+          "value": "disinfection"
+        },
+        {
+          "lang": "es",
+          "value": "Desinfección"
+        },
+        {
+          "lang": "fa",
+          "value": "گندزدایی"
+        },
+        {
+          "lang": "fr",
+          "value": "désinfection"
+        },
+        {
+          "lang": "hi",
+          "value": "विसंक्रमण"
+        },
+        {
+          "lang": "hu",
+          "value": "fertõtlenítés"
+        },
+        {
+          "lang": "it",
+          "value": "Disinfezione"
+        },
+        {
+          "lang": "ja",
+          "value": "消毒"
+        },
+        {
+          "lang": "ko",
+          "value": "소독"
+        },
+        {
+          "lang": "lo",
+          "value": "ການຂ້າເຊື້ອ"
+        },
+        {
+          "lang": "pl",
+          "value": "Dezynfekcja"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_130",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "be",
+          "value": "адміністрацыя"
+        },
+        {
+          "lang": "sw",
+          "value": "usimamiaji"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "administração"
+        },
+        {
+          "lang": "ka",
+          "value": "მმართველობა"
+        },
+        {
+          "lang": "nn",
+          "value": "administrasjon"
+        },
+        {
+          "lang": "nb",
+          "value": "administrasjon"
+        },
+        {
+          "lang": "ro",
+          "value": "administrare"
+        },
+        {
+          "lang": "te",
+          "value": "పాలన"
+        },
+        {
+          "lang": "tr",
+          "value": "idare"
+        },
+        {
+          "lang": "uk",
+          "value": "адміністрація"
+        },
+        {
+          "lang": "ms",
+          "value": "Pentadbiran"
+        },
+        {
+          "lang": "zh",
+          "value": "行政管理"
+        },
+        {
+          "lang": "th",
+          "value": "การบริหาร"
+        },
+        {
+          "lang": "sk",
+          "value": "administratíva"
+        },
+        {
+          "lang": "ru",
+          "value": "администрация"
+        },
+        {
+          "lang": "pt",
+          "value": "administração"
+        },
+        {
+          "lang": "ar",
+          "value": "إدارة تنفيذية"
+        },
+        {
+          "lang": "cs",
+          "value": "administrativa"
+        },
+        {
+          "lang": "de",
+          "value": "Administration"
+        },
+        {
+          "lang": "en",
+          "value": "administration"
+        },
+        {
+          "lang": "es",
+          "value": "Administración"
+        },
+        {
+          "lang": "fa",
+          "value": "سرپرستی"
+        },
+        {
+          "lang": "fr",
+          "value": "administration"
+        },
+        {
+          "lang": "hi",
+          "value": "प्रशासन"
+        },
+        {
+          "lang": "hu",
+          "value": "igazgatás"
+        },
+        {
+          "lang": "it",
+          "value": "Amministrazione"
+        },
+        {
+          "lang": "ja",
+          "value": "行政"
+        },
+        {
+          "lang": "ko",
+          "value": "행정"
+        },
+        {
+          "lang": "lo",
+          "value": "ການບໍລິຫານ"
+        },
+        {
+          "lang": "pl",
+          "value": "Administracja"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_1344",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "ca",
+          "value": "Cartografia"
+        },
+        {
+          "lang": "sw",
+          "value": "cartografia"
+        },
+        {
+          "lang": "be",
+          "value": "картаграфія"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "Cartografia"
+        },
+        {
+          "lang": "et",
+          "value": "kartograafia"
+        },
+        {
+          "lang": "fi",
+          "value": "kartografia"
+        },
+        {
+          "lang": "nb",
+          "value": "kartografi"
+        },
+        {
+          "lang": "el",
+          "value": "χαρτογράφηση"
+        },
+        {
+          "lang": "sv",
+          "value": "kartografi"
+        },
+        {
+          "lang": "ro",
+          "value": "cartografie"
+        },
+        {
+          "lang": "ka",
+          "value": "კარტოგრაფია"
+        },
+        {
+          "lang": "ms",
+          "value": "Kartografi"
+        },
+        {
+          "lang": "te",
+          "value": "డొథైడి యేల్స్"
+        },
+        {
+          "lang": "tr",
+          "value": "haritacılık"
+        },
+        {
+          "lang": "uk",
+          "value": "картографія"
+        },
+        {
+          "lang": "zh",
+          "value": "地图学"
+        },
+        {
+          "lang": "th",
+          "value": "แผนที่วิทยา"
+        },
+        {
+          "lang": "sk",
+          "value": "kartografia"
+        },
+        {
+          "lang": "ru",
+          "value": "картография"
+        },
+        {
+          "lang": "pt",
+          "value": "cartografia"
+        },
+        {
+          "lang": "ar",
+          "value": "علم رسم الخرائط"
+        },
+        {
+          "lang": "cs",
+          "value": "kartografie"
+        },
+        {
+          "lang": "de",
+          "value": "Kartographie"
+        },
+        {
+          "lang": "en",
+          "value": "cartography"
+        },
+        {
+          "lang": "es",
+          "value": "Cartografía"
+        },
+        {
+          "lang": "fa",
+          "value": "نقشه‌کشی"
+        },
+        {
+          "lang": "fr",
+          "value": "cartographie"
+        },
+        {
+          "lang": "hi",
+          "value": "मानचित्र बनाने की कला"
+        },
+        {
+          "lang": "hu",
+          "value": "kartográfia"
+        },
+        {
+          "lang": "it",
+          "value": "Cartografia"
+        },
+        {
+          "lang": "ja",
+          "value": "地図製作"
+        },
+        {
+          "lang": "ko",
+          "value": "해도작성법"
+        },
+        {
+          "lang": "lo",
+          "value": "ແຜນທີ່ວິທະຍາ"
+        },
+        {
+          "lang": "pl",
+          "value": "Kartografia"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_15301",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "sw",
+          "value": "kupungua kwa uzito"
+        },
+        {
+          "lang": "be",
+          "value": "зніжэнне вагі"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "redução do peso"
+        },
+        {
+          "lang": "ro",
+          "value": "reducere de greutate"
+        },
+        {
+          "lang": "ka",
+          "value": "წონის შემცირება"
+        },
+        {
+          "lang": "tr",
+          "value": "kilo azalması"
+        },
+        {
+          "lang": "zh",
+          "value": "减重"
+        },
+        {
+          "lang": "th",
+          "value": "การลดน้ำหนัก"
+        },
+        {
+          "lang": "sk",
+          "value": "znižovanie hmotnosti"
+        },
+        {
+          "lang": "ar",
+          "value": "نقص الوزن"
+        },
+        {
+          "lang": "cs",
+          "value": "snižování hmotnosti"
+        },
+        {
+          "lang": "de",
+          "value": "Gewichtsreduktion"
+        },
+        {
+          "lang": "en",
+          "value": "weight reduction"
+        },
+        {
+          "lang": "es",
+          "value": "Reducción del peso"
+        },
+        {
+          "lang": "fa",
+          "value": "کاهش وزن"
+        },
+        {
+          "lang": "fr",
+          "value": "baisse de poids"
+        },
+        {
+          "lang": "hi",
+          "value": "भार क्षरण"
+        },
+        {
+          "lang": "hu",
+          "value": "súlycsökkentés"
+        },
+        {
+          "lang": "it",
+          "value": "Riduzione di peso"
+        },
+        {
+          "lang": "ja",
+          "value": "減量"
+        },
+        {
+          "lang": "pl",
+          "value": "Obniżka masy ciała"
+        },
+        {
+          "lang": "pt",
+          "value": "redução do peso"
+        },
+        {
+          "lang": "ru",
+          "value": "снижение веса"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_15682",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "be",
+          "value": "незаконная дзейнасць"
+        },
+        {
+          "lang": "es",
+          "value": "Práctica ilegal"
+        },
+        {
+          "lang": "sw",
+          "value": "haramu mazoezi"
+        },
+        {
+          "lang": "ro",
+          "value": "practici ilegale"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "prática ilegal"
+        },
+        {
+          "lang": "ka",
+          "value": "უკანონო ქმედება"
+        },
+        {
+          "lang": "uk",
+          "value": "незаконна діяльність"
+        },
+        {
+          "lang": "te",
+          "value": "చట్ట వ్యతిరేక ఆచరణలు"
+        },
+        {
+          "lang": "tr",
+          "value": "yasa dışı uygulama"
+        },
+        {
+          "lang": "zh",
+          "value": "非法行为"
+        },
+        {
+          "lang": "th",
+          "value": "การกระทำที่ผิดกฎหมาย"
+        },
+        {
+          "lang": "sk",
+          "value": "nezákonná činnosť"
+        },
+        {
+          "lang": "ar",
+          "value": "ممارسات مخالفة القانون"
+        },
+        {
+          "lang": "cs",
+          "value": "nezákonná činnost"
+        },
+        {
+          "lang": "de",
+          "value": "ungesetzliche Methode"
+        },
+        {
+          "lang": "en",
+          "value": "illegal practices"
+        },
+        {
+          "lang": "fa",
+          "value": "اعمال غیر قانونی"
+        },
+        {
+          "lang": "fr",
+          "value": "pratique illégale"
+        },
+        {
+          "lang": "hi",
+          "value": "अवैध अभ्यास"
+        },
+        {
+          "lang": "hu",
+          "value": "törvénytelen módszer"
+        },
+        {
+          "lang": "it",
+          "value": "Pratiche illegali"
+        },
+        {
+          "lang": "ja",
+          "value": "違法行為"
+        },
+        {
+          "lang": "ko",
+          "value": "불법활동"
+        },
+        {
+          "lang": "pl",
+          "value": "Działania nielegalne"
+        },
+        {
+          "lang": "pt",
+          "value": "prática ilegal"
+        },
+        {
+          "lang": "ru",
+          "value": "незаконные действия"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_15908",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "ca",
+          "value": "Navegació"
+        },
+        {
+          "lang": "sw",
+          "value": "ongoza chombo majini"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "navegação"
+        },
+        {
+          "lang": "uk",
+          "value": "навігація"
+        },
+        {
+          "lang": "ro",
+          "value": "navigație"
+        },
+        {
+          "lang": "tr",
+          "value": "seyir"
+        },
+        {
+          "lang": "nb",
+          "value": "navigasjon"
+        },
+        {
+          "lang": "ru",
+          "value": "навигация"
+        },
+        {
+          "lang": "zh",
+          "value": "航海"
+        },
+        {
+          "lang": "th",
+          "value": "การเดินเรือ"
+        },
+        {
+          "lang": "sk",
+          "value": "navigácia"
+        },
+        {
+          "lang": "ar",
+          "value": "ملاحة"
+        },
+        {
+          "lang": "cs",
+          "value": "navigace"
+        },
+        {
+          "lang": "de",
+          "value": "Navigation"
+        },
+        {
+          "lang": "en",
+          "value": "navigation"
+        },
+        {
+          "lang": "es",
+          "value": "Navegación"
+        },
+        {
+          "lang": "fa",
+          "value": "ناوبری"
+        },
+        {
+          "lang": "fr",
+          "value": "navigation"
+        },
+        {
+          "lang": "hi",
+          "value": "नौ चालन / समुद्री परिवहन"
+        },
+        {
+          "lang": "hu",
+          "value": "navigáció"
+        },
+        {
+          "lang": "it",
+          "value": "Navigazione"
+        },
+        {
+          "lang": "ja",
+          "value": "航法"
+        },
+        {
+          "lang": "ko",
+          "value": "항해"
+        },
+        {
+          "lang": "pl",
+          "value": "Żegluga"
+        },
+        {
+          "lang": "pt",
+          "value": "navegação"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_15980",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "sr",
+          "value": "регулација раста"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "controle de cresscimento"
+        },
+        {
+          "lang": "be",
+          "value": "рэгуляцыя росту"
+        },
+        {
+          "lang": "nb",
+          "value": "vekstkontroll"
+        },
+        {
+          "lang": "sw",
+          "value": "udhibiti wa ukuaji"
+        },
+        {
+          "lang": "ro",
+          "value": "reglarea creșterii"
+        },
+        {
+          "lang": "uk",
+          "value": "регулювання росту"
+        },
+        {
+          "lang": "te",
+          "value": "పెరుగుదల నియంత్రణ"
+        },
+        {
+          "lang": "tr",
+          "value": "büyüme kontrolü"
+        },
+        {
+          "lang": "zh",
+          "value": "生长控制"
+        },
+        {
+          "lang": "th",
+          "value": "การควบคุมการเจริญเติบโต"
+        },
+        {
+          "lang": "sk",
+          "value": "riadený rast"
+        },
+        {
+          "lang": "ru",
+          "value": "регулирование роста"
+        },
+        {
+          "lang": "ar",
+          "value": "التحكم في النمو"
+        },
+        {
+          "lang": "cs",
+          "value": "řízený růst"
+        },
+        {
+          "lang": "de",
+          "value": "Wachstumssteuerung"
+        },
+        {
+          "lang": "en",
+          "value": "growth control"
+        },
+        {
+          "lang": "es",
+          "value": "Control del crecimiento"
+        },
+        {
+          "lang": "fa",
+          "value": "کنترل رشد"
+        },
+        {
+          "lang": "fr",
+          "value": "contrôle de croissance"
+        },
+        {
+          "lang": "hi",
+          "value": "वृद्धि नियंत्रण"
+        },
+        {
+          "lang": "hu",
+          "value": "növekedésellenõrzés"
+        },
+        {
+          "lang": "it",
+          "value": "Controllo della crescita"
+        },
+        {
+          "lang": "ja",
+          "value": "生長調節"
+        },
+        {
+          "lang": "ko",
+          "value": "생장조절"
+        },
+        {
+          "lang": "pl",
+          "value": "Regulacja wzrostu"
+        },
+        {
+          "lang": "pt",
+          "value": "controlo de desenvolvimento"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_16086",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "be",
+          "value": "кіраванне"
+        },
+        {
+          "lang": "sw",
+          "value": "usimamizi"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "gestão"
+        },
+        {
+          "lang": "et",
+          "value": "haldamine"
+        },
+        {
+          "lang": "ro",
+          "value": "management"
+        },
+        {
+          "lang": "ka",
+          "value": "მართვა"
+        },
+        {
+          "lang": "uk",
+          "value": "управління"
+        },
+        {
+          "lang": "tr",
+          "value": "yönetim"
+        },
+        {
+          "lang": "zh",
+          "value": "管理"
+        },
+        {
+          "lang": "th",
+          "value": "การจัดการ"
+        },
+        {
+          "lang": "sk",
+          "value": "manažment"
+        },
+        {
+          "lang": "ru",
+          "value": "управление"
+        },
+        {
+          "lang": "ar",
+          "value": "إدارة"
+        },
+        {
+          "lang": "cs",
+          "value": "řízení"
+        },
+        {
+          "lang": "de",
+          "value": "Management"
+        },
+        {
+          "lang": "en",
+          "value": "management"
+        },
+        {
+          "lang": "es",
+          "value": "Gestión"
+        },
+        {
+          "lang": "fa",
+          "value": "مدیریت"
+        },
+        {
+          "lang": "fr",
+          "value": "gestion"
+        },
+        {
+          "lang": "hi",
+          "value": "प्रबन्धन"
+        },
+        {
+          "lang": "hu",
+          "value": "menedzsment"
+        },
+        {
+          "lang": "it",
+          "value": "Gestione"
+        },
+        {
+          "lang": "ja",
+          "value": "管理"
+        },
+        {
+          "lang": "ko",
+          "value": "경영"
+        },
+        {
+          "lang": "pl",
+          "value": "Zarządzanie"
+        },
+        {
+          "lang": "pt",
+          "value": "gestão"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_1653",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "be",
+          "value": "класіфікацыя"
+        },
+        {
+          "lang": "sw",
+          "value": "uainishaji"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "classificação"
+        },
+        {
+          "lang": "et",
+          "value": "klassifikatsioon"
+        },
+        {
+          "lang": "nb",
+          "value": "klassifikasjon"
+        },
+        {
+          "lang": "ro",
+          "value": "clasificare"
+        },
+        {
+          "lang": "ka",
+          "value": "კლასიფიკაცია"
+        },
+        {
+          "lang": "ms",
+          "value": "Pengelasan"
+        },
+        {
+          "lang": "tr",
+          "value": "sınıflandırma"
+        },
+        {
+          "lang": "uk",
+          "value": "класифікація"
+        },
+        {
+          "lang": "zh",
+          "value": "分类"
+        },
+        {
+          "lang": "th",
+          "value": "การจำแนกหมวดหมู่"
+        },
+        {
+          "lang": "sk",
+          "value": "klasifikácia"
+        },
+        {
+          "lang": "ru",
+          "value": "классификации"
+        },
+        {
+          "lang": "pt",
+          "value": "classificação"
+        },
+        {
+          "lang": "ar",
+          "value": "تصنيف"
+        },
+        {
+          "lang": "cs",
+          "value": "klasifikace"
+        },
+        {
+          "lang": "de",
+          "value": "Klassifikation"
+        },
+        {
+          "lang": "en",
+          "value": "classification"
+        },
+        {
+          "lang": "es",
+          "value": "Clasificación"
+        },
+        {
+          "lang": "fa",
+          "value": "رده‌بندی"
+        },
+        {
+          "lang": "fr",
+          "value": "classification"
+        },
+        {
+          "lang": "hi",
+          "value": "वर्गीकरण"
+        },
+        {
+          "lang": "hu",
+          "value": "osztályba történő besorolás"
+        },
+        {
+          "lang": "it",
+          "value": "Classificazione"
+        },
+        {
+          "lang": "ja",
+          "value": "分類"
+        },
+        {
+          "lang": "ko",
+          "value": "분류"
+        },
+        {
+          "lang": "lo",
+          "value": "ການຈັດແບ່ງ"
+        },
+        {
+          "lang": "pl",
+          "value": "Klasyfikacja"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_1661",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "sr",
+          "value": "чишћење"
+        },
+        {
+          "lang": "sw",
+          "value": "kusafisha"
+        },
+        {
+          "lang": "ka",
+          "value": "გაწმენდა"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "limpeza"
+        },
+        {
+          "lang": "nb",
+          "value": "rengjøring"
+        },
+        {
+          "lang": "fi",
+          "value": "siivous"
+        },
+        {
+          "lang": "id",
+          "value": "Kebersihan"
+        },
+        {
+          "lang": "sv",
+          "value": "städning"
+        },
+        {
+          "lang": "da",
+          "value": "rengøring"
+        },
+        {
+          "lang": "ca",
+          "value": "Neteja"
+        },
+        {
+          "lang": "ro",
+          "value": "curăţare"
+        },
+        {
+          "lang": "ms",
+          "value": "Pembersihan"
+        },
+        {
+          "lang": "tr",
+          "value": "temizleme"
+        },
+        {
+          "lang": "uk",
+          "value": "очищення"
+        },
+        {
+          "lang": "zh",
+          "value": "清理"
+        },
+        {
+          "lang": "th",
+          "value": "การทำความสะอาด"
+        },
+        {
+          "lang": "sk",
+          "value": "čistenie"
+        },
+        {
+          "lang": "ru",
+          "value": "очистка"
+        },
+        {
+          "lang": "ar",
+          "value": "تنظيف"
+        },
+        {
+          "lang": "cs",
+          "value": "čištění"
+        },
+        {
+          "lang": "de",
+          "value": "Reinigung"
+        },
+        {
+          "lang": "en",
+          "value": "cleaning"
+        },
+        {
+          "lang": "es",
+          "value": "Limpieza"
+        },
+        {
+          "lang": "fr",
+          "value": "nettoyage"
+        },
+        {
+          "lang": "hi",
+          "value": "सफाई करना"
+        },
+        {
+          "lang": "hu",
+          "value": "tisztítás"
+        },
+        {
+          "lang": "it",
+          "value": "Pulitura"
+        },
+        {
+          "lang": "ja",
+          "value": "清掃"
+        },
+        {
+          "lang": "ko",
+          "value": "세정"
+        },
+        {
+          "lang": "lo",
+          "value": "ການທຳຄວາມສະອາດ"
+        },
+        {
+          "lang": "pl",
+          "value": "Czyszczenie"
+        },
+        {
+          "lang": "pt",
+          "value": "limpeza"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_1856",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "be",
+          "value": "кааператыўная дзейнасць"
+        },
+        {
+          "lang": "es",
+          "value": "Actividad cooperativa"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "atividade cooperativa"
+        },
+        {
+          "lang": "sw",
+          "value": "shughuli za ushirika"
+        },
+        {
+          "lang": "ka",
+          "value": "კოოპერატიული საქმიანობა"
+        },
+        {
+          "lang": "ms",
+          "value": "Aktiviti kerjasama"
+        },
+        {
+          "lang": "uk",
+          "value": "кооперативна діяльність"
+        },
+        {
+          "lang": "tr",
+          "value": "ortak etkinlik"
+        },
+        {
+          "lang": "zh",
+          "value": "合作活动"
+        },
+        {
+          "lang": "th",
+          "value": "กิจกรรมสหกรณ์"
+        },
+        {
+          "lang": "sk",
+          "value": "družstevníctvo"
+        },
+        {
+          "lang": "ru",
+          "value": "кооперативная деятельность"
+        },
+        {
+          "lang": "ar",
+          "value": "نشاطات تعاونية"
+        },
+        {
+          "lang": "cs",
+          "value": "družstevnictví"
+        },
+        {
+          "lang": "de",
+          "value": "Genossenschaftstätigkeit"
+        },
+        {
+          "lang": "en",
+          "value": "cooperative activities"
+        },
+        {
+          "lang": "fa",
+          "value": "فعالیت‌های تعاونی"
+        },
+        {
+          "lang": "fr",
+          "value": "activité coopérative"
+        },
+        {
+          "lang": "hi",
+          "value": "सहकारी गतिविधियाँ"
+        },
+        {
+          "lang": "hu",
+          "value": "szövetkezeti tevékenység"
+        },
+        {
+          "lang": "it",
+          "value": "Attività cooperative"
+        },
+        {
+          "lang": "ja",
+          "value": "協同活動"
+        },
+        {
+          "lang": "ko",
+          "value": "조합활동"
+        },
+        {
+          "lang": "lo",
+          "value": "ວຽກງານສະຫະກອນ"
+        },
+        {
+          "lang": "pl",
+          "value": "Działalność spółdzielcza"
+        },
+        {
+          "lang": "pt",
+          "value": "actividade cooperativa"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_2042f69b",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "ru",
+          "value": "удаление"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "remoção"
+        },
+        {
+          "lang": "sw",
+          "value": "kuondoa"
+        },
+        {
+          "lang": "ar",
+          "value": "إزالة"
+        },
+        {
+          "lang": "zh",
+          "value": "消除"
+        },
+        {
+          "lang": "de",
+          "value": "Beseitigung"
+        },
+        {
+          "lang": "cs",
+          "value": "odstranění"
+        },
+        {
+          "lang": "tr",
+          "value": "çıkarma"
+        },
+        {
+          "lang": "pt",
+          "value": "remoção"
+        },
+        {
+          "lang": "nb",
+          "value": "fjerning"
+        },
+        {
+          "lang": "fr",
+          "value": "enlèvement"
+        },
+        {
+          "lang": "es",
+          "value": "Remoción"
+        },
+        {
+          "lang": "en",
+          "value": "removal"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_20c81b80",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "sw",
+          "value": "malipo ya kuokoa"
+        },
+        {
+          "lang": "ru",
+          "value": "сбор обломков"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "salvamento"
+        },
+        {
+          "lang": "ar",
+          "value": "إنْقاذ"
+        },
+        {
+          "lang": "zh",
+          "value": "救生"
+        },
+        {
+          "lang": "es",
+          "value": "Salvamento"
+        },
+        {
+          "lang": "cs",
+          "value": "zachraňování"
+        },
+        {
+          "lang": "fr",
+          "value": "récupération d'épaves"
+        },
+        {
+          "lang": "tr",
+          "value": "kurtarma"
+        },
+        {
+          "lang": "de",
+          "value": "Bergung"
+        },
+        {
+          "lang": "nb",
+          "value": "berging"
+        },
+        {
+          "lang": "en",
+          "value": "salvaging"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_2208",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "sv",
+          "value": "design"
+        },
+        {
+          "lang": "nn",
+          "value": "design"
+        },
+        {
+          "lang": "da",
+          "value": "design"
+        },
+        {
+          "lang": "sr",
+          "value": "дизајн"
+        },
+        {
+          "lang": "be",
+          "value": "дызайн"
+        },
+        {
+          "lang": "vi",
+          "value": "thiết kế"
+        },
+        {
+          "lang": "sw",
+          "value": "kubuni"
+        },
+        {
+          "lang": "nb",
+          "value": "design"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "design"
+        },
+        {
+          "lang": "ru",
+          "value": "дизайн"
+        },
+        {
+          "lang": "ro",
+          "value": "design"
+        },
+        {
+          "lang": "uk",
+          "value": "проект"
+        },
+        {
+          "lang": "tr",
+          "value": "tasarım"
+        },
+        {
+          "lang": "zh",
+          "value": "设计"
+        },
+        {
+          "lang": "th",
+          "value": "การออกแบบ"
+        },
+        {
+          "lang": "sk",
+          "value": "dizajn"
+        },
+        {
+          "lang": "pt",
+          "value": "design"
+        },
+        {
+          "lang": "ar",
+          "value": "تصميم"
+        },
+        {
+          "lang": "cs",
+          "value": "design"
+        },
+        {
+          "lang": "de",
+          "value": "Entwurf"
+        },
+        {
+          "lang": "en",
+          "value": "design"
+        },
+        {
+          "lang": "es",
+          "value": "Diseño"
+        },
+        {
+          "lang": "fa",
+          "value": "طراحی"
+        },
+        {
+          "lang": "fr",
+          "value": "conception"
+        },
+        {
+          "lang": "hi",
+          "value": "रूपरेखा"
+        },
+        {
+          "lang": "hu",
+          "value": "terv"
+        },
+        {
+          "lang": "it",
+          "value": "Progetto"
+        },
+        {
+          "lang": "ja",
+          "value": "設計"
+        },
+        {
+          "lang": "ko",
+          "value": "설계"
+        },
+        {
+          "lang": "lo",
+          "value": "ການອອກແບບ"
+        },
+        {
+          "lang": "pl",
+          "value": "Projekt"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_2238",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "sr",
+          "value": "дијагноза"
+        },
+        {
+          "lang": "ka",
+          "value": "დიაგნოზი"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "diagnóstico"
+        },
+        {
+          "lang": "ro",
+          "value": "diagnostic"
+        },
+        {
+          "lang": "ca",
+          "value": "Diagnòstic"
+        },
+        {
+          "lang": "sw",
+          "value": "utambuzi wa kimatibabu"
+        },
+        {
+          "lang": "my",
+          "value": "ရောဂါအမည်ဖော်ထုတ်ခြင်း"
+        },
+        {
+          "lang": "vi",
+          "value": "chẩn đoán"
+        },
+        {
+          "lang": "nb",
+          "value": "diagnose"
+        },
+        {
+          "lang": "fi",
+          "value": "diagnoosi"
+        },
+        {
+          "lang": "sv",
+          "value": "diagnos"
+        },
+        {
+          "lang": "da",
+          "value": "diagnose"
+        },
+        {
+          "lang": "uk",
+          "value": "діагностика"
+        },
+        {
+          "lang": "tr",
+          "value": "tanı"
+        },
+        {
+          "lang": "zh",
+          "value": "诊断"
+        },
+        {
+          "lang": "th",
+          "value": "การวินิจฉัยโรค"
+        },
+        {
+          "lang": "sk",
+          "value": "diagnóza"
+        },
+        {
+          "lang": "ru",
+          "value": "диагностика"
+        },
+        {
+          "lang": "pt",
+          "value": "diagnóstico"
+        },
+        {
+          "lang": "ar",
+          "value": "تشخيص"
+        },
+        {
+          "lang": "cs",
+          "value": "diagnóza"
+        },
+        {
+          "lang": "de",
+          "value": "Diagnose"
+        },
+        {
+          "lang": "en",
+          "value": "diagnosis"
+        },
+        {
+          "lang": "es",
+          "value": "Diagnóstico"
+        },
+        {
+          "lang": "fa",
+          "value": "تشخیص (پزشکی)"
+        },
+        {
+          "lang": "fr",
+          "value": "diagnostic"
+        },
+        {
+          "lang": "hi",
+          "value": "निदान रोग का"
+        },
+        {
+          "lang": "hu",
+          "value": "diagnózis"
+        },
+        {
+          "lang": "it",
+          "value": "Diagnosi"
+        },
+        {
+          "lang": "ja",
+          "value": "診断"
+        },
+        {
+          "lang": "ko",
+          "value": "진단"
+        },
+        {
+          "lang": "lo",
+          "value": "ການບົ່ງມະຕີພະຍາດສັດ"
+        },
+        {
+          "lang": "pl",
+          "value": "Diagnostyka"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_230f84ce",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "ru",
+          "value": "переоборудование судна"
+        },
+        {
+          "lang": "sw",
+          "value": "ubadilishaji wa meli"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "conversão de navio"
+        },
+        {
+          "lang": "ar",
+          "value": "تحويل السفينة"
+        },
+        {
+          "lang": "zh",
+          "value": "船舶改装"
+        },
+        {
+          "lang": "es",
+          "value": "Conversión de barcos"
+        },
+        {
+          "lang": "cs",
+          "value": "přestavba lodi"
+        },
+        {
+          "lang": "tr",
+          "value": "gemi dönüştürme"
+        },
+        {
+          "lang": "fr",
+          "value": "conversion de navire"
+        },
+        {
+          "lang": "en",
+          "value": "ship conversion"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_24016",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "be",
+          "value": "знішчэнне жывёл"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "destruição de animais"
+        },
+        {
+          "lang": "sw",
+          "value": "uharibifu wa wanyama"
+        },
+        {
+          "lang": "ro",
+          "value": "distrugerea animalelor"
+        },
+        {
+          "lang": "uk",
+          "value": "знищення тварин"
+        },
+        {
+          "lang": "zh",
+          "value": "处死动物"
+        },
+        {
+          "lang": "th",
+          "value": "การทำลายสัตว์"
+        },
+        {
+          "lang": "sk",
+          "value": "usmrcovanie zvierat"
+        },
+        {
+          "lang": "ru",
+          "value": "уничтожение животных"
+        },
+        {
+          "lang": "pt",
+          "value": "destruição de animais"
+        },
+        {
+          "lang": "tr",
+          "value": "hayvan itlafı"
+        },
+        {
+          "lang": "ar",
+          "value": "إبادة الحيوان"
+        },
+        {
+          "lang": "cs",
+          "value": "usmrcování zvířat"
+        },
+        {
+          "lang": "de",
+          "value": "Tötung von Tieren"
+        },
+        {
+          "lang": "en",
+          "value": "destruction of animals"
+        },
+        {
+          "lang": "es",
+          "value": "Destrucción de animales"
+        },
+        {
+          "lang": "fa",
+          "value": "انهدام جانوران"
+        },
+        {
+          "lang": "fr",
+          "value": "destruction d'animaux"
+        },
+        {
+          "lang": "hi",
+          "value": "पशुओं का नाश"
+        },
+        {
+          "lang": "hu",
+          "value": "állat megsemmisítése"
+        },
+        {
+          "lang": "it",
+          "value": "Soppressione di animali"
+        },
+        {
+          "lang": "ja",
+          "value": "屠殺（食用以外の）、動物駆除"
+        },
+        {
+          "lang": "lo",
+          "value": "ການທຳລາຍສັດ"
+        },
+        {
+          "lang": "pl",
+          "value": "Uśmiercanie zwierząt"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_24105",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "sw",
+          "value": "kukamata wanyama"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "captura de animais"
+        },
+        {
+          "lang": "ro",
+          "value": "capturare de animale"
+        },
+        {
+          "lang": "ms",
+          "value": "Penangkapan haiwan"
+        },
+        {
+          "lang": "tr",
+          "value": "hayvan yakalama"
+        },
+        {
+          "lang": "uk",
+          "value": "піймання тварин"
+        },
+        {
+          "lang": "zh",
+          "value": "动物捕捉"
+        },
+        {
+          "lang": "th",
+          "value": "การดักจับสัตว์"
+        },
+        {
+          "lang": "sk",
+          "value": "lov zvierat"
+        },
+        {
+          "lang": "ru",
+          "value": "добыча животных"
+        },
+        {
+          "lang": "pt",
+          "value": "captura de animais"
+        },
+        {
+          "lang": "ar",
+          "value": "أسر الحيوان"
+        },
+        {
+          "lang": "cs",
+          "value": "chytání zvířat"
+        },
+        {
+          "lang": "de",
+          "value": "Tierfang"
+        },
+        {
+          "lang": "en",
+          "value": "capture of animals"
+        },
+        {
+          "lang": "es",
+          "value": "Captura animal"
+        },
+        {
+          "lang": "fa",
+          "value": "شکار جانوران"
+        },
+        {
+          "lang": "fr",
+          "value": "capture animale"
+        },
+        {
+          "lang": "hi",
+          "value": "पशुओं को पकड़ना"
+        },
+        {
+          "lang": "hu",
+          "value": "állatbefogás"
+        },
+        {
+          "lang": "it",
+          "value": "Cattura degli animali"
+        },
+        {
+          "lang": "ja",
+          "value": "動物捕獲"
+        },
+        {
+          "lang": "ko",
+          "value": "동물포획"
+        },
+        {
+          "lang": "lo",
+          "value": "ການດັກຈັບສັດ"
+        },
+        {
+          "lang": "pl",
+          "value": "Chwytanie zwierząt"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_2488",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "ro",
+          "value": "învățământ"
+        },
+        {
+          "lang": "be",
+          "value": "адукацыя"
+        },
+        {
+          "lang": "da",
+          "value": "uddannelse"
+        },
+        {
+          "lang": "sv",
+          "value": "utbildning"
+        },
+        {
+          "lang": "nn",
+          "value": "utdanning"
+        },
+        {
+          "lang": "sw",
+          "value": "elimu"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "educação"
+        },
+        {
+          "lang": "nb",
+          "value": "utdanning"
+        },
+        {
+          "lang": "ka",
+          "value": "განათლება"
+        },
+        {
+          "lang": "uk",
+          "value": "освіта"
+        },
+        {
+          "lang": "te",
+          "value": "విద్యా"
+        },
+        {
+          "lang": "tr",
+          "value": "eğitim"
+        },
+        {
+          "lang": "zh",
+          "value": "教育"
+        },
+        {
+          "lang": "th",
+          "value": "การศึกษา"
+        },
+        {
+          "lang": "sk",
+          "value": "vzdelávanie, vzdelanie"
+        },
+        {
+          "lang": "ru",
+          "value": "образование"
+        },
+        {
+          "lang": "pt",
+          "value": "educação"
+        },
+        {
+          "lang": "ar",
+          "value": "تربية"
+        },
+        {
+          "lang": "cs",
+          "value": "vzdělávání"
+        },
+        {
+          "lang": "de",
+          "value": "Bildung"
+        },
+        {
+          "lang": "en",
+          "value": "education"
+        },
+        {
+          "lang": "es",
+          "value": "Educación"
+        },
+        {
+          "lang": "fa",
+          "value": "آموزش"
+        },
+        {
+          "lang": "fr",
+          "value": "éducation"
+        },
+        {
+          "lang": "hi",
+          "value": "शिक्षा"
+        },
+        {
+          "lang": "hu",
+          "value": "oktatás"
+        },
+        {
+          "lang": "it",
+          "value": "Istruzione"
+        },
+        {
+          "lang": "ja",
+          "value": "教育"
+        },
+        {
+          "lang": "ko",
+          "value": "교육"
+        },
+        {
+          "lang": "lo",
+          "value": "ການສຶກສາ"
+        },
+        {
+          "lang": "pl",
+          "value": "Edukacja"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_25103",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "be",
+          "value": "дрэваапрацоўка"
+        },
+        {
+          "lang": "ro",
+          "value": "prelucrarea lemnului"
+        },
+        {
+          "lang": "sw",
+          "value": "kazi ya mbao"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "marcenaria"
+        },
+        {
+          "lang": "uk",
+          "value": "деревообробка"
+        },
+        {
+          "lang": "tr",
+          "value": "ağaç işleri"
+        },
+        {
+          "lang": "zh",
+          "value": "木材加工"
+        },
+        {
+          "lang": "th",
+          "value": "งานอุตสาหกรรมไม้"
+        },
+        {
+          "lang": "sk",
+          "value": "spracovanie dreva"
+        },
+        {
+          "lang": "ru",
+          "value": "деревообработка"
+        },
+        {
+          "lang": "pt",
+          "value": "trabalho da madeira"
+        },
+        {
+          "lang": "ar",
+          "value": "أشغال خشبية"
+        },
+        {
+          "lang": "cs",
+          "value": "zpracování dřeva"
+        },
+        {
+          "lang": "de",
+          "value": "Holzbearbeitung"
+        },
+        {
+          "lang": "en",
+          "value": "woodworking"
+        },
+        {
+          "lang": "es",
+          "value": "Elaboración de la madera"
+        },
+        {
+          "lang": "fa",
+          "value": "نجاری"
+        },
+        {
+          "lang": "fr",
+          "value": "travail du bois"
+        },
+        {
+          "lang": "hi",
+          "value": "काष्ठ कार्यकी"
+        },
+        {
+          "lang": "hu",
+          "value": "fafeldolgozás"
+        },
+        {
+          "lang": "it",
+          "value": "Lavorazione del legno"
+        },
+        {
+          "lang": "ja",
+          "value": "木工"
+        },
+        {
+          "lang": "ko",
+          "value": "목공"
+        },
+        {
+          "lang": "lo",
+          "value": "ວຽກກ່ຽວກັບໄມ້"
+        },
+        {
+          "lang": "pl",
+          "value": "Przerób drewna"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_2520",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "sw",
+          "value": "umeme"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "eletrificação"
+        },
+        {
+          "lang": "nb",
+          "value": "elektrifisering"
+        },
+        {
+          "lang": "nl",
+          "value": "elektrificatie"
+        },
+        {
+          "lang": "fi",
+          "value": "sähköistys"
+        },
+        {
+          "lang": "sv",
+          "value": "elektrifiering"
+        },
+        {
+          "lang": "ru",
+          "value": "электрификация"
+        },
+        {
+          "lang": "ka",
+          "value": "ელექტრიფიკაცია"
+        },
+        {
+          "lang": "ro",
+          "value": "electrificare"
+        },
+        {
+          "lang": "uk",
+          "value": "електрифікація"
+        },
+        {
+          "lang": "te",
+          "value": "విద్యుదీకరణము"
+        },
+        {
+          "lang": "tr",
+          "value": "elektrifikasyon"
+        },
+        {
+          "lang": "zh",
+          "value": "电气化"
+        },
+        {
+          "lang": "th",
+          "value": "การผลิตไฟฟ้า"
+        },
+        {
+          "lang": "sk",
+          "value": "elektrifikácia"
+        },
+        {
+          "lang": "pt",
+          "value": "electrificação"
+        },
+        {
+          "lang": "ar",
+          "value": "كهربة"
+        },
+        {
+          "lang": "cs",
+          "value": "elektrifikace"
+        },
+        {
+          "lang": "de",
+          "value": "Elektrifizierung"
+        },
+        {
+          "lang": "en",
+          "value": "electrification"
+        },
+        {
+          "lang": "es",
+          "value": "Electrificación"
+        },
+        {
+          "lang": "fa",
+          "value": "برق‌رسانی"
+        },
+        {
+          "lang": "fr",
+          "value": "électrification"
+        },
+        {
+          "lang": "hi",
+          "value": "विधुतीकरण"
+        },
+        {
+          "lang": "hu",
+          "value": "villamosítás"
+        },
+        {
+          "lang": "it",
+          "value": "Elettrificazione"
+        },
+        {
+          "lang": "ja",
+          "value": "電化"
+        },
+        {
+          "lang": "ko",
+          "value": "전화"
+        },
+        {
+          "lang": "lo",
+          "value": "ການຜະລິດໄຟຟ້າ"
+        },
+        {
+          "lang": "pl",
+          "value": "Elektryfikacja"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_26950",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "be",
+          "value": "лоўля рыбы"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "pesca"
+        },
+        {
+          "lang": "vi",
+          "value": "khai thác thủy sản"
+        },
+        {
+          "lang": "nn",
+          "value": "fiske"
+        },
+        {
+          "lang": "sv",
+          "value": "fiske"
+        },
+        {
+          "lang": "sw",
+          "value": "uvuvi"
+        },
+        {
+          "lang": "fr",
+          "value": "pêche"
+        },
+        {
+          "lang": "ar",
+          "value": "صيد السمك"
+        },
+        {
+          "lang": "nb",
+          "value": "fiske"
+        },
+        {
+          "lang": "ka",
+          "value": "თევზაობა"
+        },
+        {
+          "lang": "es",
+          "value": "Pesca"
+        },
+        {
+          "lang": "uk",
+          "value": "рибальство"
+        },
+        {
+          "lang": "de",
+          "value": "Fischen"
+        },
+        {
+          "lang": "te",
+          "value": "చేపల వేట"
+        },
+        {
+          "lang": "tr",
+          "value": "balık avlama"
+        },
+        {
+          "lang": "ko",
+          "value": "어로"
+        },
+        {
+          "lang": "cs",
+          "value": "lov ryb"
+        },
+        {
+          "lang": "en",
+          "value": "fishing"
+        },
+        {
+          "lang": "fa",
+          "value": "ماهيگيري"
+        },
+        {
+          "lang": "hi",
+          "value": "मछली पकड़ना"
+        },
+        {
+          "lang": "hu",
+          "value": "halászat"
+        },
+        {
+          "lang": "it",
+          "value": "Attività di pesca"
+        },
+        {
+          "lang": "ja",
+          "value": "漁獲"
+        },
+        {
+          "lang": "lo",
+          "value": "ການຕຶກເບັດ"
+        },
+        {
+          "lang": "pl",
+          "value": "Połowy ryb"
+        },
+        {
+          "lang": "ru",
+          "value": "рыбный лов"
+        },
+        {
+          "lang": "sk",
+          "value": "rybolov"
+        },
+        {
+          "lang": "th",
+          "value": "การจับสัตว์น้ำ"
+        },
+        {
+          "lang": "zh",
+          "value": "捕捞"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_2736",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "sr",
+          "value": "евалуација"
+        },
+        {
+          "lang": "nn",
+          "value": "evaluering"
+        },
+        {
+          "lang": "sw",
+          "value": "tathmini"
+        },
+        {
+          "lang": "be",
+          "value": "ацэнка"
+        },
+        {
+          "lang": "nb",
+          "value": "evaluering"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "avaliação"
+        },
+        {
+          "lang": "et",
+          "value": "hindamine"
+        },
+        {
+          "lang": "ro",
+          "value": "evaluare"
+        },
+        {
+          "lang": "uk",
+          "value": "оценка"
+        },
+        {
+          "lang": "te",
+          "value": "మూల్యాంకనము"
+        },
+        {
+          "lang": "tr",
+          "value": "değerlendirme"
+        },
+        {
+          "lang": "zh",
+          "value": "评估"
+        },
+        {
+          "lang": "th",
+          "value": "การประเมินผล"
+        },
+        {
+          "lang": "sk",
+          "value": "hodnotenie"
+        },
+        {
+          "lang": "ru",
+          "value": "оценка"
+        },
+        {
+          "lang": "pt",
+          "value": "avaliação"
+        },
+        {
+          "lang": "ar",
+          "value": "تقويم"
+        },
+        {
+          "lang": "cs",
+          "value": "hodnocení"
+        },
+        {
+          "lang": "de",
+          "value": "Auswertung"
+        },
+        {
+          "lang": "en",
+          "value": "evaluation"
+        },
+        {
+          "lang": "es",
+          "value": "Evaluación"
+        },
+        {
+          "lang": "fa",
+          "value": "ارزشیابی"
+        },
+        {
+          "lang": "fr",
+          "value": "contrôle continu"
+        },
+        {
+          "lang": "hi",
+          "value": "मूल्यांकन"
+        },
+        {
+          "lang": "hu",
+          "value": "kiértékelés"
+        },
+        {
+          "lang": "it",
+          "value": "Valutazione"
+        },
+        {
+          "lang": "ja",
+          "value": "評価"
+        },
+        {
+          "lang": "ko",
+          "value": "평가"
+        },
+        {
+          "lang": "lo",
+          "value": "ການປະເມີນຜົນ"
+        },
+        {
+          "lang": "pl",
+          "value": "Ocena"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_275cbac9",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "es",
+          "value": "Operación militare"
+        },
+        {
+          "lang": "uk",
+          "value": "бойові дії"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "operação militar"
+        },
+        {
+          "lang": "en",
+          "value": "military operations"
+        },
+        {
+          "lang": "cs",
+          "value": "vojenské operace"
+        },
+        {
+          "lang": "nl",
+          "value": "militaire operaties"
+        },
+        {
+          "lang": "ka",
+          "value": "სამხედრო ოპერაცია"
+        },
+        {
+          "lang": "tr",
+          "value": "askerî harekât"
+        },
+        {
+          "lang": "it",
+          "value": "Operazioni militari"
+        },
+        {
+          "lang": "de",
+          "value": "Militäroperation"
+        },
+        {
+          "lang": "ro",
+          "value": "operații miltare"
+        },
+        {
+          "lang": "nb",
+          "value": "militære operasjoner"
+        },
+        {
+          "lang": "fr",
+          "value": "opération militaire"
+        },
+        {
+          "lang": "ru",
+          "value": "боевые действия"
+        },
+        {
+          "lang": "zh",
+          "value": "军事行动"
+        },
+        {
+          "lang": "ar",
+          "value": "العمليات العسكرية"
+        },
+        {
+          "lang": "sw",
+          "value": "shughuli za kijeshi"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_28116",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "sw",
+          "value": "kutengeneza karatasi"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "fabricação de papel"
+        },
+        {
+          "lang": "ro",
+          "value": "fabricarea hârtiei"
+        },
+        {
+          "lang": "fi",
+          "value": "paperinvalmistus"
+        },
+        {
+          "lang": "sv",
+          "value": "papperstillverkning"
+        },
+        {
+          "lang": "uk",
+          "value": "виробництво паперу"
+        },
+        {
+          "lang": "tr",
+          "value": "kağıt yapımı"
+        },
+        {
+          "lang": "zh",
+          "value": "造纸"
+        },
+        {
+          "lang": "th",
+          "value": "การทำกระดาษ"
+        },
+        {
+          "lang": "sk",
+          "value": "výroba papiera"
+        },
+        {
+          "lang": "ru",
+          "value": "производство бумаги"
+        },
+        {
+          "lang": "ar",
+          "value": "صناعة الورق"
+        },
+        {
+          "lang": "cs",
+          "value": "výroba papíru"
+        },
+        {
+          "lang": "de",
+          "value": "Papierherstellung"
+        },
+        {
+          "lang": "en",
+          "value": "papermaking"
+        },
+        {
+          "lang": "es",
+          "value": "Fabricación de papel"
+        },
+        {
+          "lang": "fa",
+          "value": "کاغذسازی"
+        },
+        {
+          "lang": "fr",
+          "value": "fabrication du papier"
+        },
+        {
+          "lang": "hi",
+          "value": "कागज का बनाना"
+        },
+        {
+          "lang": "hu",
+          "value": "papírkészítés"
+        },
+        {
+          "lang": "it",
+          "value": "Fabbricazione della carta"
+        },
+        {
+          "lang": "ja",
+          "value": "製紙"
+        },
+        {
+          "lang": "lo",
+          "value": "ການຜະລິດເຈ້ຍ"
+        },
+        {
+          "lang": "pl",
+          "value": "Papiernictwo"
+        },
+        {
+          "lang": "pt",
+          "value": "fabricação de papel"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_2838",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "ro",
+          "value": "alimentație"
+        },
+        {
+          "lang": "be",
+          "value": "кармленне"
+        },
+        {
+          "lang": "sw",
+          "value": "kulisha"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "alimentação"
+        },
+        {
+          "lang": "uk",
+          "value": "годування"
+        },
+        {
+          "lang": "te",
+          "value": "సంభరణం"
+        },
+        {
+          "lang": "tr",
+          "value": "besleme"
+        },
+        {
+          "lang": "zh",
+          "value": "饲养"
+        },
+        {
+          "lang": "th",
+          "value": "การให้อาหาร"
+        },
+        {
+          "lang": "sk",
+          "value": "kŕmenie"
+        },
+        {
+          "lang": "ru",
+          "value": "кормление"
+        },
+        {
+          "lang": "pt",
+          "value": "alimentação"
+        },
+        {
+          "lang": "ar",
+          "value": "علف"
+        },
+        {
+          "lang": "cs",
+          "value": "krmení"
+        },
+        {
+          "lang": "de",
+          "value": "Fütterung"
+        },
+        {
+          "lang": "en",
+          "value": "feeding"
+        },
+        {
+          "lang": "es",
+          "value": "Alimentación"
+        },
+        {
+          "lang": "fa",
+          "value": "تغذیه دام"
+        },
+        {
+          "lang": "fr",
+          "value": "alimentation"
+        },
+        {
+          "lang": "hi",
+          "value": "पोषण/ आहार"
+        },
+        {
+          "lang": "hu",
+          "value": "etetés"
+        },
+        {
+          "lang": "it",
+          "value": "Alimentazione"
+        },
+        {
+          "lang": "ja",
+          "value": "給餌"
+        },
+        {
+          "lang": "ko",
+          "value": "사양"
+        },
+        {
+          "lang": "lo",
+          "value": "ການໃຫ້ອາຫານ"
+        },
+        {
+          "lang": "pl",
+          "value": "Żywienie"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_2908",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "pt-BR",
+          "value": "controle de incêndio"
+        },
+        {
+          "lang": "sw",
+          "value": "udhibiti wa moto"
+        },
+        {
+          "lang": "zh",
+          "value": "消防"
+        },
+        {
+          "lang": "ro",
+          "value": "combaterea incendiilor"
+        },
+        {
+          "lang": "uk",
+          "value": "боротьба з пожежами"
+        },
+        {
+          "lang": "te",
+          "value": "మంటల నియంత్రణ"
+        },
+        {
+          "lang": "tr",
+          "value": "yangın kontrolü"
+        },
+        {
+          "lang": "th",
+          "value": "การควบคุมไฟ"
+        },
+        {
+          "lang": "sk",
+          "value": "protipožiarna ochrana"
+        },
+        {
+          "lang": "ru",
+          "value": "борьба с пожарами"
+        },
+        {
+          "lang": "pt",
+          "value": "controlo de incêndios"
+        },
+        {
+          "lang": "ar",
+          "value": "مكافحة الحرائق"
+        },
+        {
+          "lang": "cs",
+          "value": "požární ochrana"
+        },
+        {
+          "lang": "de",
+          "value": "Brandschutz"
+        },
+        {
+          "lang": "en",
+          "value": "fire control"
+        },
+        {
+          "lang": "es",
+          "value": "Control de incendios"
+        },
+        {
+          "lang": "fa",
+          "value": "کنترل آتش‌سوزی"
+        },
+        {
+          "lang": "fr",
+          "value": "lutte anti-incendie"
+        },
+        {
+          "lang": "hi",
+          "value": "अग्नि नियंत्रण"
+        },
+        {
+          "lang": "hu",
+          "value": "tûzvédelem"
+        },
+        {
+          "lang": "it",
+          "value": "Lotta agli incendi"
+        },
+        {
+          "lang": "ja",
+          "value": "消火"
+        },
+        {
+          "lang": "ko",
+          "value": "화재방지"
+        },
+        {
+          "lang": "lo",
+          "value": "ການຄວບຄຸມໄຟ"
+        },
+        {
+          "lang": "pl",
+          "value": "Ochrona przeciwpożarowa"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_2952",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "be",
+          "value": "рыбалоўная аперацыя"
+        },
+        {
+          "lang": "sw",
+          "value": "operesheni za kuvua samaki"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "operação de pesca"
+        },
+        {
+          "lang": "es",
+          "value": "Operaciónes de pesca"
+        },
+        {
+          "lang": "uk",
+          "value": "риболовецькі операції"
+        },
+        {
+          "lang": "te",
+          "value": "చేపలు పట్టే పనులు"
+        },
+        {
+          "lang": "tr",
+          "value": "balık avcılığı keşif çalışması"
+        },
+        {
+          "lang": "zh",
+          "value": "捕捞作业"
+        },
+        {
+          "lang": "th",
+          "value": "กิจกรรมการประมง"
+        },
+        {
+          "lang": "sk",
+          "value": "rybárske činnosti"
+        },
+        {
+          "lang": "ru",
+          "value": "рыболовные операции"
+        },
+        {
+          "lang": "hi",
+          "value": "मछली पकड़ने की क्रिया"
+        },
+        {
+          "lang": "ar",
+          "value": "عمليات صيد الأسماك"
+        },
+        {
+          "lang": "cs",
+          "value": "rybářské činnosti"
+        },
+        {
+          "lang": "de",
+          "value": "Fischfang"
+        },
+        {
+          "lang": "en",
+          "value": "fishing operations"
+        },
+        {
+          "lang": "fa",
+          "value": "عملیات ماهیگیری"
+        },
+        {
+          "lang": "fr",
+          "value": "opération de pêche"
+        },
+        {
+          "lang": "hu",
+          "value": "hafogás"
+        },
+        {
+          "lang": "it",
+          "value": "Operazioni di pesca"
+        },
+        {
+          "lang": "ja",
+          "value": "漁労"
+        },
+        {
+          "lang": "ko",
+          "value": "조업"
+        },
+        {
+          "lang": "lo",
+          "value": "ກິດຈະກຳການຫາປາ"
+        },
+        {
+          "lang": "pl",
+          "value": "Eksploatacja rybacka"
+        },
+        {
+          "lang": "pt",
+          "value": "operação de pesca"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_2c4fa234",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "pt",
+          "value": "operação portuária"
+        },
+        {
+          "lang": "sw",
+          "value": "shughuli za bandari"
+        },
+        {
+          "lang": "es",
+          "value": "Operación portuaria"
+        },
+        {
+          "lang": "ru",
+          "value": "портовые операции"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "operação portuária"
+        },
+        {
+          "lang": "ar",
+          "value": "عمليات الميناء"
+        },
+        {
+          "lang": "zh",
+          "value": "港口业务"
+        },
+        {
+          "lang": "cs",
+          "value": "provoz přístavu"
+        },
+        {
+          "lang": "nb",
+          "value": "havneoperasjoner"
+        },
+        {
+          "lang": "de",
+          "value": "Hafenbetrieb"
+        },
+        {
+          "lang": "tr",
+          "value": "liman işlemleri"
+        },
+        {
+          "lang": "it",
+          "value": "Operazioni portuali"
+        },
+        {
+          "lang": "fr",
+          "value": "opération portuaire"
+        },
+        {
+          "lang": "en",
+          "value": "port operations"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_2e39cd37",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "ro",
+          "value": "expediții"
+        },
+        {
+          "lang": "sw",
+          "value": "wepesi"
+        },
+        {
+          "lang": "es",
+          "value": "Expedición"
+        },
+        {
+          "lang": "en",
+          "value": "expeditions"
+        },
+        {
+          "lang": "nb",
+          "value": "ekspedisjoner"
+        },
+        {
+          "lang": "fr",
+          "value": "expédition (voyage)"
+        },
+        {
+          "lang": "tr",
+          "value": "keşif gezisi"
+        },
+        {
+          "lang": "de",
+          "value": "Expedition"
+        },
+        {
+          "lang": "cs",
+          "value": "expedice"
+        },
+        {
+          "lang": "ka",
+          "value": "ექსპედიცია"
+        },
+        {
+          "lang": "uk",
+          "value": "експедиції"
+        },
+        {
+          "lang": "zh",
+          "value": "考察"
+        },
+        {
+          "lang": "nn",
+          "value": "ekspedisjonar"
+        },
+        {
+          "lang": "ru",
+          "value": "экспедиции"
+        },
+        {
+          "lang": "ar",
+          "value": "بعثات"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "expedição"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_3041",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "nn",
+          "value": "prognosar"
+        },
+        {
+          "lang": "nl",
+          "value": "voorspelling"
+        },
+        {
+          "lang": "sw",
+          "value": "maaguzi"
+        },
+        {
+          "lang": "be",
+          "value": "прагназаванне"
+        },
+        {
+          "lang": "sr",
+          "value": "прогнозирање"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "previsão"
+        },
+        {
+          "lang": "nb",
+          "value": "prognoser"
+        },
+        {
+          "lang": "ka",
+          "value": "პროგნოზირება"
+        },
+        {
+          "lang": "ro",
+          "value": "prognozare"
+        },
+        {
+          "lang": "uk",
+          "value": "прогнозування"
+        },
+        {
+          "lang": "te",
+          "value": "పూర్వానుమానం"
+        },
+        {
+          "lang": "tr",
+          "value": "tahmin"
+        },
+        {
+          "lang": "zh",
+          "value": "预测"
+        },
+        {
+          "lang": "th",
+          "value": "การพยากรณ์"
+        },
+        {
+          "lang": "sk",
+          "value": "prognózovanie"
+        },
+        {
+          "lang": "ru",
+          "value": "прогнозирование"
+        },
+        {
+          "lang": "pt",
+          "value": "previsão"
+        },
+        {
+          "lang": "ar",
+          "value": "تنبؤ"
+        },
+        {
+          "lang": "cs",
+          "value": "prognózování"
+        },
+        {
+          "lang": "de",
+          "value": "Prognose"
+        },
+        {
+          "lang": "en",
+          "value": "forecasting"
+        },
+        {
+          "lang": "es",
+          "value": "Predicción"
+        },
+        {
+          "lang": "fa",
+          "value": "پیش‌بینی"
+        },
+        {
+          "lang": "fr",
+          "value": "prévision"
+        },
+        {
+          "lang": "hi",
+          "value": "भविष्यवाणी"
+        },
+        {
+          "lang": "hu",
+          "value": "elõrejelzés"
+        },
+        {
+          "lang": "it",
+          "value": "Previsioni"
+        },
+        {
+          "lang": "ja",
+          "value": "予測"
+        },
+        {
+          "lang": "ko",
+          "value": "예찰"
+        },
+        {
+          "lang": "lo",
+          "value": "ການພະຍາກອນ"
+        },
+        {
+          "lang": "pl",
+          "value": "Prognozowanie"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_3055",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "se",
+          "value": "vuovdedoallu"
+        },
+        {
+          "lang": "sv",
+          "value": "skogsbruk"
+        },
+        {
+          "lang": "sr",
+          "value": "шумарство"
+        },
+        {
+          "lang": "es",
+          "value": "Ciencia forestal"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "Silvicultura"
+        },
+        {
+          "lang": "zh",
+          "value": "林学"
+        },
+        {
+          "lang": "it",
+          "value": "Scienze forestali"
+        },
+        {
+          "lang": "ro",
+          "value": "activități forestiere"
+        },
+        {
+          "lang": "sw",
+          "value": "elimu misitu"
+        },
+        {
+          "lang": "nb",
+          "value": "skogbruk"
+        },
+        {
+          "lang": "fi",
+          "value": "metsätalous"
+        },
+        {
+          "lang": "ka",
+          "value": "მეტყევეობა"
+        },
+        {
+          "lang": "my",
+          "value": "သစ်တော"
+        },
+        {
+          "lang": "vi",
+          "value": "lâm nghiệp"
+        },
+        {
+          "lang": "km",
+          "value": "រុក្ខាប្រមាញ់"
+        },
+        {
+          "lang": "uk",
+          "value": "лісівництво"
+        },
+        {
+          "lang": "te",
+          "value": "అటవీ శాస్త్రం"
+        },
+        {
+          "lang": "tr",
+          "value": "ormancılık"
+        },
+        {
+          "lang": "th",
+          "value": "วนศาสตร์"
+        },
+        {
+          "lang": "sk",
+          "value": "lesníctvo"
+        },
+        {
+          "lang": "ar",
+          "value": "زراعة الغابات"
+        },
+        {
+          "lang": "cs",
+          "value": "lesnictví"
+        },
+        {
+          "lang": "de",
+          "value": "Forstwirtschaft"
+        },
+        {
+          "lang": "en",
+          "value": "forestry"
+        },
+        {
+          "lang": "fa",
+          "value": "جنگلداری"
+        },
+        {
+          "lang": "fr",
+          "value": "foresterie"
+        },
+        {
+          "lang": "hi",
+          "value": "वानिकी"
+        },
+        {
+          "lang": "hu",
+          "value": "erdészet"
+        },
+        {
+          "lang": "ja",
+          "value": "林業"
+        },
+        {
+          "lang": "ko",
+          "value": "임업"
+        },
+        {
+          "lang": "lo",
+          "value": "ວັນນະສາດ"
+        },
+        {
+          "lang": "pl",
+          "value": "Leśnictwo"
+        },
+        {
+          "lang": "pt",
+          "value": "actividade florestal"
+        },
+        {
+          "lang": "ru",
+          "value": "лесное хозяйство"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_3059",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "sw",
+          "value": "shughuli za elimu misitu"
+        },
+        {
+          "lang": "es",
+          "value": "Operación forestal"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "operação florestal"
+        },
+        {
+          "lang": "uk",
+          "value": "лісогосподарські операції"
+        },
+        {
+          "lang": "te",
+          "value": "అటవీ కార్యములు"
+        },
+        {
+          "lang": "tr",
+          "value": "ormancılık çalışması"
+        },
+        {
+          "lang": "zh",
+          "value": "森林操作"
+        },
+        {
+          "lang": "th",
+          "value": "การดำเนินการป่าไม้"
+        },
+        {
+          "lang": "sk",
+          "value": "lesnícke činnosti"
+        },
+        {
+          "lang": "ru",
+          "value": "лесохозяйственные операции"
+        },
+        {
+          "lang": "ar",
+          "value": "عمليات التحريج"
+        },
+        {
+          "lang": "cs",
+          "value": "lesnické činnosti"
+        },
+        {
+          "lang": "de",
+          "value": "Waldarbeit"
+        },
+        {
+          "lang": "en",
+          "value": "forestry operations"
+        },
+        {
+          "lang": "fa",
+          "value": "عملیات جنگلداری"
+        },
+        {
+          "lang": "fr",
+          "value": "opération forestière"
+        },
+        {
+          "lang": "hi",
+          "value": "वानिकी कार्य"
+        },
+        {
+          "lang": "hu",
+          "value": "erdõmûvelés"
+        },
+        {
+          "lang": "it",
+          "value": "Operazioni di selvicoltura"
+        },
+        {
+          "lang": "ja",
+          "value": "森林作業"
+        },
+        {
+          "lang": "ko",
+          "value": "산림작업"
+        },
+        {
+          "lang": "lo",
+          "value": "ການປະຕິບັດການປ່າໄມ້"
+        },
+        {
+          "lang": "pl",
+          "value": "Czynności gospodarcze w leśnictwie"
+        },
+        {
+          "lang": "pt",
+          "value": "operação florestal"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_330834",
+      "type": "skos:Concept",
+      "dct:created": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2008-09-25T00:00:00Z"
+      },
+      "dct:modified": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2025-07-22T11:15:34"
+      },
+      "http://rdfs.org/ns/void#inDataset": {
+        "uri": "http://aims.fao.org/aos/agrovoc/void.ttl#Agrovoc"
+      },
+      "altLabel": [
+        {
+          "lang": "tr",
+          "value": "faaliyet"
+        },
+        {
+          "lang": "de",
+          "value": "Tätigkeit"
+        },
+        {
+          "lang": "tr",
+          "value": "aktivite"
+        }
+      ],
+      "skos:definition": [
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/xDef_d8a81e42"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/xDef_47a14ae7"
+        }
+      ],
+      "exactMatch": [
+        {
+          "uri": "http://www.cadastralvocabulary.org/CaLAThe/Activity"
+        },
+        {
+          "uri": "https://vocabularyserver.com/cnr/ml/earth/en/xml.php?skosTema=96040"
+        }
+      ],
+      "hiddenLabel": {
+        "lang": "es",
+        "value": "Actividades"
+      },
+      "inScheme": {
+        "uri": "http://aims.fao.org/aos/agrovoc"
+      },
+      "narrower": [
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_5bbac269"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_88ebf476"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_f3efcce8"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_b9d1a9fd"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_deb98e72"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_42b93387"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_bc882050"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_74f047e5"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_e6e33ae1"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_50bccb82"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_3c73540e"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_aafbf0c8"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_2e39cd37"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_d2e42ffb"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_50c7fa97"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_c3c7073b"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_7eb51b94"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_275cbac9"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_20c81b80"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_2042f69b"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_c4d65583"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_7bae3d7d"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_816e729b"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_4bde1dcc"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_2c4fa234"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_230f84ce"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_a97eb278"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_c9d7e397"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_782dd4c3"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_487829e6"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_4721b818"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_bea12d1e"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_9e278097"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_15682"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_1856"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_3041"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_2838"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_1653"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_6352"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_2488"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_25103"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_3485"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_7645"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_5828"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_2736"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_35702"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_5951"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_7533"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_4620"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_3954"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_2952"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_37866"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_16086"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_7427"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_7402"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_7401"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_6477"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_6195"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_5965"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_3055"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_1344"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_9000086"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_331576"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_331462"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_331436"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_330990"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_330917"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_330899"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_330898"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_330897"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_330896"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_330895"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_330894"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_330888"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_50345"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_37343"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_28116"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_24016"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_330858"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_37602"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_10179"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_15908"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_7874"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_6940"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_6513"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_6220"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_6200"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_15301"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_4911"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_4668"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_3894"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_3822"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_3791"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_24105"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_3697"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_5495"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_2908"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_49928"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_1661"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_6989"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_8152"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_62"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_50119"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_7848"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_3059"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_2520"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_3900"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_35060"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_7536"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_4524"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_130"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_26950"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_49902"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_10397"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_2238"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_8339"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_15980"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/c_2208"
+        }
+      ],
+      "prefLabel": [
+        {
+          "lang": "th",
+          "value": "กิจกรรม"
+        },
+        {
+          "lang": "sv",
+          "value": "aktiviteter"
+        },
+        {
+          "lang": "es",
+          "value": "Actividad"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "atividades"
+        },
+        {
+          "lang": "nn",
+          "value": "aktivitetar"
+        },
+        {
+          "lang": "da",
+          "value": "aktiviteter"
+        },
+        {
+          "lang": "sk",
+          "value": "aktivity"
+        },
+        {
+          "lang": "hi",
+          "value": "कार्यकलाप"
+        },
+        {
+          "lang": "ar",
+          "value": "انشطة"
+        },
+        {
+          "lang": "sr",
+          "value": "активност"
+        },
+        {
+          "lang": "sw",
+          "value": "shughuli"
+        },
+        {
+          "lang": "en",
+          "value": "activities"
+        },
+        {
+          "lang": "fr",
+          "value": "activité"
+        },
+        {
+          "lang": "zh",
+          "value": "活动"
+        },
+        {
+          "lang": "ms",
+          "value": "Aktiviti"
+        },
+        {
+          "lang": "cs",
+          "value": "aktivity"
+        },
+        {
+          "lang": "de",
+          "value": "Aktivität"
+        },
+        {
+          "lang": "it",
+          "value": "Attività"
+        },
+        {
+          "lang": "tr",
+          "value": "etkinlik"
+        },
+        {
+          "lang": "uk",
+          "value": "діяльність"
+        },
+        {
+          "lang": "ro",
+          "value": "activităţi"
+        },
+        {
+          "lang": "ru",
+          "value": "деятельность"
+        },
+        {
+          "lang": "ka",
+          "value": "საქმიანობა"
+        },
+        {
+          "lang": "nb",
+          "value": "aktiviteter"
+        },
+        {
+          "lang": "pt",
+          "value": "atividades"
+        }
+      ],
+      "skos:topConceptOf": {
+        "uri": "http://aims.fao.org/aos/agrovoc"
+      },
+      "http://www.w3.org/2008/05/skos-xl#altLabel": [
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/xl_tr_1331561625299"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/xl_tr_1331561600472"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/xl_de_1343897781451"
+        }
+      ],
+      "http://www.w3.org/2008/05/skos-xl#hiddenLabel": {
+        "uri": "http://aims.fao.org/aos/agrovoc/xl_es_1299517186084"
+      },
+      "http://www.w3.org/2008/05/skos-xl#prefLabel": [
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/xl_th_005d60d5"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/xl_sv_65101db3"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/xl_es_e9941e63"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/xl_pt-BR_ec1c6b34"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/xl_nn_c5f6c38b"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/xl_da_5aa40889"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/xl_sk_cd40f8e0"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/xl_hi_348fcc8f"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/xl_ar_c979e918"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/xl_sr_ddbf4a14"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/xl_sw_de9acdf6"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/xl_pt_eb06086f"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/xl_nb_cc1ed7c8"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/xl_ka_f8a4263f"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/xl_ru_e4b731e7"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/xl_ro_616d11c2"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/xl_uk_1336988245814"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/xl_tr_1331561573252"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/xl_it_1330936584382"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/xl_de_1330936550823"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/xl_cs_1318924441012"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/xl_ms_1313985585804"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/xl_zh_1303260548028"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/xl_fr_1299517186101"
+        },
+        {
+          "uri": "http://aims.fao.org/aos/agrovoc/xl_en_1299517186066"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_330858",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "zh",
+          "value": "收获前作业"
+        },
+        {
+          "lang": "en",
+          "value": "preharvest operation"
+        },
+        {
+          "lang": "hi",
+          "value": "कटाई के पहले की क्रियायें"
+        },
+        {
+          "lang": "de",
+          "value": "Aktivitäten vor der Ernte"
+        },
+        {
+          "lang": "tr",
+          "value": "hasat öncesi işlem"
+        },
+        {
+          "lang": "cs",
+          "value": "předsklizňové operace"
+        },
+        {
+          "lang": "it",
+          "value": "Operazioni preraccolta"
+        },
+        {
+          "lang": "uk",
+          "value": "передзбиральний захід"
+        },
+        {
+          "lang": "ru",
+          "value": "предуборочные операции"
+        },
+        {
+          "lang": "fr",
+          "value": "opération de pré-récolte"
+        },
+        {
+          "lang": "ar",
+          "value": "عملية ما قبل الحصاد"
+        },
+        {
+          "lang": "es",
+          "value": "Operación previa a la cosecha"
+        },
+        {
+          "lang": "be",
+          "value": "перадуборачныя аперацыі"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "operação pré-colheita"
+        },
+        {
+          "lang": "sw",
+          "value": "shughuli ya kabla ya mavuno"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_330888",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "th",
+          "value": "กิจกรรมทางเศรษฐกิจ"
+        },
+        {
+          "lang": "es",
+          "value": "Actividad económica"
+        },
+        {
+          "lang": "sw",
+          "value": "shughuli za kiuchumi"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "atividade econômica"
+        },
+        {
+          "lang": "en",
+          "value": "economic activities"
+        },
+        {
+          "lang": "fr",
+          "value": "activité économique"
+        },
+        {
+          "lang": "cs",
+          "value": "ekonomické aktivity"
+        },
+        {
+          "lang": "uk",
+          "value": "економічна діяльність"
+        },
+        {
+          "lang": "de",
+          "value": "wirtschaftliche Aktivität"
+        },
+        {
+          "lang": "it",
+          "value": "Attività economiche"
+        },
+        {
+          "lang": "tr",
+          "value": "ekonomik faaliyet"
+        },
+        {
+          "lang": "ro",
+          "value": "activităţi economice"
+        },
+        {
+          "lang": "ka",
+          "value": "ეკონომიკური საქმიანობა"
+        },
+        {
+          "lang": "sr",
+          "value": "економске активности"
+        },
+        {
+          "lang": "ru",
+          "value": "экономическая деятельность"
+        },
+        {
+          "lang": "ar",
+          "value": "الأنشطة الاقتصادية"
+        },
+        {
+          "lang": "nb",
+          "value": "økonomiske aktiviteter"
+        },
+        {
+          "lang": "zh",
+          "value": "经济活动"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_330894",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "pt-BR",
+          "value": "organização"
+        },
+        {
+          "lang": "sw",
+          "value": "shirika"
+        },
+        {
+          "lang": "en",
+          "value": "organization"
+        },
+        {
+          "lang": "ko",
+          "value": "기질화"
+        },
+        {
+          "lang": "cs",
+          "value": "organizace"
+        },
+        {
+          "lang": "de",
+          "value": "Organisierung"
+        },
+        {
+          "lang": "it",
+          "value": "Organizzazione"
+        },
+        {
+          "lang": "tr",
+          "value": "organizasyon"
+        },
+        {
+          "lang": "uk",
+          "value": "організація"
+        },
+        {
+          "lang": "ru",
+          "value": "организация"
+        },
+        {
+          "lang": "ka",
+          "value": "ორგანიზება"
+        },
+        {
+          "lang": "da",
+          "value": "organisering"
+        },
+        {
+          "lang": "nb",
+          "value": "organisering"
+        },
+        {
+          "lang": "fr",
+          "value": "organisation (activité)"
+        },
+        {
+          "lang": "es",
+          "value": "Organización"
+        },
+        {
+          "lang": "ar",
+          "value": "مُنَظَّمَة"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_330895",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "th",
+          "value": "การทปรับปรุงแก้ไข"
+        },
+        {
+          "lang": "zh",
+          "value": "改进"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "melhoria"
+        },
+        {
+          "lang": "sw",
+          "value": "kuendeleza"
+        },
+        {
+          "lang": "uk",
+          "value": "поліпшення"
+        },
+        {
+          "lang": "ko",
+          "value": "개선"
+        },
+        {
+          "lang": "en",
+          "value": "improvement"
+        },
+        {
+          "lang": "de",
+          "value": "Verbesserung"
+        },
+        {
+          "lang": "it",
+          "value": "Miglioramento"
+        },
+        {
+          "lang": "tr",
+          "value": "iyileştirme"
+        },
+        {
+          "lang": "cs",
+          "value": "zlepšení"
+        },
+        {
+          "lang": "ru",
+          "value": "улучшение"
+        },
+        {
+          "lang": "nb",
+          "value": "forbedring"
+        },
+        {
+          "lang": "ka",
+          "value": "გაუმჯობესება"
+        },
+        {
+          "lang": "ro",
+          "value": "îmbunătățire"
+        },
+        {
+          "lang": "fr",
+          "value": "amélioration"
+        },
+        {
+          "lang": "ar",
+          "value": "تحسين"
+        },
+        {
+          "lang": "es",
+          "value": "Mejoramiento"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_330896",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "nl",
+          "value": "bescherming"
+        },
+        {
+          "lang": "pt",
+          "value": "proteção"
+        },
+        {
+          "lang": "da",
+          "value": "beskyttelse"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "proteção"
+        },
+        {
+          "lang": "zh",
+          "value": "保护"
+        },
+        {
+          "lang": "ar",
+          "value": "حِمَايَة"
+        },
+        {
+          "lang": "ro",
+          "value": "protecție"
+        },
+        {
+          "lang": "sw",
+          "value": "kukinga"
+        },
+        {
+          "lang": "tr",
+          "value": "koruma"
+        },
+        {
+          "lang": "en",
+          "value": "protection"
+        },
+        {
+          "lang": "es",
+          "value": "Protección"
+        },
+        {
+          "lang": "fr",
+          "value": "protection"
+        },
+        {
+          "lang": "ko",
+          "value": "보호"
+        },
+        {
+          "lang": "cs",
+          "value": "ochrana"
+        },
+        {
+          "lang": "it",
+          "value": "Protezione"
+        },
+        {
+          "lang": "de",
+          "value": "Schutz"
+        },
+        {
+          "lang": "uk",
+          "value": "захист"
+        },
+        {
+          "lang": "ru",
+          "value": "защита"
+        },
+        {
+          "lang": "ka",
+          "value": "დაცვა"
+        },
+        {
+          "lang": "vi",
+          "value": "sự bảo vệ"
+        },
+        {
+          "lang": "nb",
+          "value": "beskyttelse"
+        },
+        {
+          "lang": "my",
+          "value": "ကာကွယ်မှု"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_330897",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "zh",
+          "value": "复兴"
+        },
+        {
+          "lang": "ru",
+          "value": "экологическая реабилитация"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "reabilitação"
+        },
+        {
+          "lang": "sw",
+          "value": "kurudisha cheo"
+        },
+        {
+          "lang": "ro",
+          "value": "reabilitare"
+        },
+        {
+          "lang": "nb",
+          "value": "rehabilitering"
+        },
+        {
+          "lang": "en",
+          "value": "rehabilitation"
+        },
+        {
+          "lang": "ko",
+          "value": "재건"
+        },
+        {
+          "lang": "de",
+          "value": "Rehabilitation"
+        },
+        {
+          "lang": "tr",
+          "value": "rehabilitasyon"
+        },
+        {
+          "lang": "cs",
+          "value": "obnova"
+        },
+        {
+          "lang": "it",
+          "value": "Riabilitazione"
+        },
+        {
+          "lang": "uk",
+          "value": "відновлення"
+        },
+        {
+          "lang": "es",
+          "value": "Rehabilitación"
+        },
+        {
+          "lang": "fr",
+          "value": "réhabilitation"
+        },
+        {
+          "lang": "ar",
+          "value": "إعادة تأهيل"
+        },
+        {
+          "lang": "ga",
+          "value": "athshlánú"
+        },
+        {
+          "lang": "da",
+          "value": "rehabilitering"
+        },
+        {
+          "lang": "el",
+          "value": "αποκατάσταση"
+        },
+        {
+          "lang": "sv",
+          "value": "rehabilitering"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_330898",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "th",
+          "value": "การรวบรวม"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "coleção"
+        },
+        {
+          "lang": "ru",
+          "value": "сбор"
+        },
+        {
+          "lang": "sk",
+          "value": "zber"
+        },
+        {
+          "lang": "zh",
+          "value": "采集"
+        },
+        {
+          "lang": "en",
+          "value": "collection"
+        },
+        {
+          "lang": "ko",
+          "value": "집하"
+        },
+        {
+          "lang": "ms",
+          "value": "Pengumpulan"
+        },
+        {
+          "lang": "cs",
+          "value": "sběr"
+        },
+        {
+          "lang": "uk",
+          "value": "збирання"
+        },
+        {
+          "lang": "de",
+          "value": "Erfassung"
+        },
+        {
+          "lang": "it",
+          "value": "Raccolta"
+        },
+        {
+          "lang": "tr",
+          "value": "toplama"
+        },
+        {
+          "lang": "nb",
+          "value": "innsamling"
+        },
+        {
+          "lang": "fr",
+          "value": "collecte"
+        },
+        {
+          "lang": "es",
+          "value": "Colección (actividad)"
+        },
+        {
+          "lang": "ar",
+          "value": "مَجْمُوعَة"
+        },
+        {
+          "lang": "sw",
+          "value": "mkusanyo"
+        },
+        {
+          "lang": "ka",
+          "value": "შეგროვება"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_330899",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "th",
+          "value": "การติดฉลาก"
+        },
+        {
+          "lang": "zh",
+          "value": "贴标签"
+        },
+        {
+          "lang": "es",
+          "value": "Etiquetado"
+        },
+        {
+          "lang": "ar",
+          "value": "وسم"
+        },
+        {
+          "lang": "en",
+          "value": "labelling"
+        },
+        {
+          "lang": "ko",
+          "value": "표지"
+        },
+        {
+          "lang": "cs",
+          "value": "označování"
+        },
+        {
+          "lang": "de",
+          "value": "Kennzeichnung"
+        },
+        {
+          "lang": "tr",
+          "value": "etiketleme"
+        },
+        {
+          "lang": "uk",
+          "value": "етикетування"
+        },
+        {
+          "lang": "it",
+          "value": "Etichettatura"
+        },
+        {
+          "lang": "ka",
+          "value": "ეტიკეტირება"
+        },
+        {
+          "lang": "ru",
+          "value": "маркировка"
+        },
+        {
+          "lang": "ro",
+          "value": "etichetare"
+        },
+        {
+          "lang": "fr",
+          "value": "étiquetage"
+        },
+        {
+          "lang": "sw",
+          "value": "kubandika"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "marcação"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_330917",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "be",
+          "value": "даследаванні"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "exploração"
+        },
+        {
+          "lang": "sw",
+          "value": "upelelezi"
+        },
+        {
+          "lang": "en",
+          "value": "exploration"
+        },
+        {
+          "lang": "ko",
+          "value": "탐사"
+        },
+        {
+          "lang": "cs",
+          "value": "průzkum"
+        },
+        {
+          "lang": "tr",
+          "value": "keşif"
+        },
+        {
+          "lang": "de",
+          "value": "Erforschung"
+        },
+        {
+          "lang": "it",
+          "value": "Esplorazione"
+        },
+        {
+          "lang": "uk",
+          "value": "експлорація"
+        },
+        {
+          "lang": "ru",
+          "value": "эксплорация"
+        },
+        {
+          "lang": "es",
+          "value": "Exploración"
+        },
+        {
+          "lang": "fr",
+          "value": "exploration"
+        },
+        {
+          "lang": "nb",
+          "value": "utforskning"
+        },
+        {
+          "lang": "ro",
+          "value": "explorare"
+        },
+        {
+          "lang": "ar",
+          "value": "استكشاف"
+        },
+        {
+          "lang": "zh",
+          "value": "勘探"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_330990",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "ru",
+          "value": "оценка (принятие решений)"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "avaliação crítica"
+        },
+        {
+          "lang": "it",
+          "value": "Quantificazione"
+        },
+        {
+          "lang": "hi",
+          "value": "आकलन"
+        },
+        {
+          "lang": "ar",
+          "value": "تقيييم"
+        },
+        {
+          "lang": "sw",
+          "value": "makadirio"
+        },
+        {
+          "lang": "nl",
+          "value": "beoordeling"
+        },
+        {
+          "lang": "es",
+          "value": "Evaluación"
+        },
+        {
+          "lang": "pt",
+          "value": "avaliação"
+        },
+        {
+          "lang": "th",
+          "value": "การประเมิน"
+        },
+        {
+          "lang": "zh",
+          "value": "评价"
+        },
+        {
+          "lang": "en",
+          "value": "assessment"
+        },
+        {
+          "lang": "cs",
+          "value": "sčítání"
+        },
+        {
+          "lang": "uk",
+          "value": "оцінювання"
+        },
+        {
+          "lang": "de",
+          "value": "Einschätzung"
+        },
+        {
+          "lang": "tr",
+          "value": "durum tespiti"
+        },
+        {
+          "lang": "ms",
+          "value": "Taksiran"
+        },
+        {
+          "lang": "km",
+          "value": "ការវាយតម្លៃ"
+        },
+        {
+          "lang": "vi",
+          "value": "đánh giá"
+        },
+        {
+          "lang": "my",
+          "value": "စစ်တမ်း"
+        },
+        {
+          "lang": "fr",
+          "value": "évaluation"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_331436",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "th",
+          "value": "การประยุกต์ใช้"
+        },
+        {
+          "lang": "pt",
+          "value": "aplicação"
+        },
+        {
+          "lang": "zh",
+          "value": "施用"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "aplicação"
+        },
+        {
+          "lang": "ru",
+          "value": "применение"
+        },
+        {
+          "lang": "en",
+          "value": "application"
+        },
+        {
+          "lang": "uk",
+          "value": "застосування"
+        },
+        {
+          "lang": "cs",
+          "value": "aplikace"
+        },
+        {
+          "lang": "de",
+          "value": "Anwendung"
+        },
+        {
+          "lang": "it",
+          "value": "Applicazione"
+        },
+        {
+          "lang": "tr",
+          "value": "toprak uygulamaları"
+        },
+        {
+          "lang": "ms",
+          "value": "Aplikasi"
+        },
+        {
+          "lang": "sr",
+          "value": "апликација"
+        },
+        {
+          "lang": "ro",
+          "value": "aplicare"
+        },
+        {
+          "lang": "fr",
+          "value": "application"
+        },
+        {
+          "lang": "ar",
+          "value": "تطبيق"
+        },
+        {
+          "lang": "es",
+          "value": "Aplicación"
+        },
+        {
+          "lang": "ka",
+          "value": "გამოყენება"
+        },
+        {
+          "lang": "sw",
+          "value": "maombi"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_331462",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "pt",
+          "value": "relatório de acidente"
+        },
+        {
+          "lang": "th",
+          "value": "การรายงานอุบัติเหตุ"
+        },
+        {
+          "lang": "zh",
+          "value": "事故报告"
+        },
+        {
+          "lang": "en",
+          "value": "accident reporting"
+        },
+        {
+          "lang": "ms",
+          "value": "Laporan kemalangan"
+        },
+        {
+          "lang": "cs",
+          "value": "hlášení havárií"
+        },
+        {
+          "lang": "uk",
+          "value": "звітність про нещасні випадки"
+        },
+        {
+          "lang": "de",
+          "value": "Unfallmeldung"
+        },
+        {
+          "lang": "tr",
+          "value": "kaza raporlama"
+        },
+        {
+          "lang": "it",
+          "value": "Comunicazione di sinistro"
+        },
+        {
+          "lang": "fr",
+          "value": "déclaration d'accident"
+        },
+        {
+          "lang": "ar",
+          "value": "الإبلاغ عن الحوادث"
+        },
+        {
+          "lang": "es",
+          "value": "Reporte de accidentes"
+        },
+        {
+          "lang": "be",
+          "value": "справаздача аб няшчасных выпадках"
+        },
+        {
+          "lang": "ru",
+          "value": "уведомление о несчастных случаях"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "relatório de acidente"
+        },
+        {
+          "lang": "sw",
+          "value": "taarifa ya ajali"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_331576",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "pt-BR",
+          "value": "busca e resgate"
+        },
+        {
+          "lang": "sw",
+          "value": "tafuta katika na ponya"
+        },
+        {
+          "lang": "en",
+          "value": "search and rescue"
+        },
+        {
+          "lang": "es",
+          "value": "Búsqueda y rescate"
+        },
+        {
+          "lang": "fr",
+          "value": "recherche et sauvetage"
+        },
+        {
+          "lang": "tr",
+          "value": "arama kurtarma"
+        },
+        {
+          "lang": "cs",
+          "value": "pátrací a záchranná služba"
+        },
+        {
+          "lang": "it",
+          "value": "Ricerca e recupero"
+        },
+        {
+          "lang": "de",
+          "value": "Suche und Rettung"
+        },
+        {
+          "lang": "uk",
+          "value": "пошуково-рятувальні роботи"
+        },
+        {
+          "lang": "ru",
+          "value": "поисково-спасательные работы"
+        },
+        {
+          "lang": "ro",
+          "value": "căutare și salvare"
+        },
+        {
+          "lang": "ka",
+          "value": "სამძებრო-სამაშველო სამუშაოები"
+        },
+        {
+          "lang": "nb",
+          "value": "søk og redning"
+        },
+        {
+          "lang": "ar",
+          "value": "البحث والإنقاذ"
+        },
+        {
+          "lang": "zh",
+          "value": "搜救"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_3485",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "be",
+          "value": "пагрузачна-разгрузачныя работы"
+        },
+        {
+          "lang": "sw",
+          "value": "kushughulikia"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "manipulação"
+        },
+        {
+          "lang": "nb",
+          "value": "håndtering"
+        },
+        {
+          "lang": "ro",
+          "value": "manipulare"
+        },
+        {
+          "lang": "uk",
+          "value": "вантажно-розвантажувальні роботи"
+        },
+        {
+          "lang": "te",
+          "value": "చేపట్టడం"
+        },
+        {
+          "lang": "tr",
+          "value": "elle işleme"
+        },
+        {
+          "lang": "ms",
+          "value": "Pengendalian"
+        },
+        {
+          "lang": "zh",
+          "value": "装卸"
+        },
+        {
+          "lang": "th",
+          "value": "การลำเลียง"
+        },
+        {
+          "lang": "sk",
+          "value": "manipulácia"
+        },
+        {
+          "lang": "ru",
+          "value": "погрузочно-разгрузочные работы"
+        },
+        {
+          "lang": "pt",
+          "value": "manipulação"
+        },
+        {
+          "lang": "ar",
+          "value": "مناولة"
+        },
+        {
+          "lang": "cs",
+          "value": "manipulace"
+        },
+        {
+          "lang": "de",
+          "value": "Handhabung"
+        },
+        {
+          "lang": "en",
+          "value": "handling"
+        },
+        {
+          "lang": "es",
+          "value": "Manipulación"
+        },
+        {
+          "lang": "fa",
+          "value": "جابجایی"
+        },
+        {
+          "lang": "fr",
+          "value": "manutention"
+        },
+        {
+          "lang": "hi",
+          "value": "प्रतिपादन"
+        },
+        {
+          "lang": "hu",
+          "value": "árukezelés"
+        },
+        {
+          "lang": "it",
+          "value": "Movimentazione"
+        },
+        {
+          "lang": "ja",
+          "value": "運搬"
+        },
+        {
+          "lang": "ko",
+          "value": "상품취급"
+        },
+        {
+          "lang": "lo",
+          "value": "ການລຳລຽງ"
+        },
+        {
+          "lang": "pl",
+          "value": "Transport bliski materiałów"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_35060",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "pt-BR",
+          "value": "construção"
+        },
+        {
+          "lang": "sw",
+          "value": "mjengo"
+        },
+        {
+          "lang": "ka",
+          "value": "მშენებლობა"
+        },
+        {
+          "lang": "ro",
+          "value": "construcții"
+        },
+        {
+          "lang": "uk",
+          "value": "будівництво"
+        },
+        {
+          "lang": "tr",
+          "value": "inşaat"
+        },
+        {
+          "lang": "zh",
+          "value": "建设"
+        },
+        {
+          "lang": "th",
+          "value": "การก่อสร้าง"
+        },
+        {
+          "lang": "sk",
+          "value": "konštrukcia"
+        },
+        {
+          "lang": "ru",
+          "value": "строительство"
+        },
+        {
+          "lang": "pt",
+          "value": "Construção"
+        },
+        {
+          "lang": "ar",
+          "value": "بناء"
+        },
+        {
+          "lang": "cs",
+          "value": "konstrukce"
+        },
+        {
+          "lang": "de",
+          "value": "Bau (Konstruktion)"
+        },
+        {
+          "lang": "en",
+          "value": "construction"
+        },
+        {
+          "lang": "es",
+          "value": "Construcción"
+        },
+        {
+          "lang": "fa",
+          "value": "ساخت"
+        },
+        {
+          "lang": "fr",
+          "value": "construction"
+        },
+        {
+          "lang": "hi",
+          "value": "निर्माण"
+        },
+        {
+          "lang": "hu",
+          "value": "építés"
+        },
+        {
+          "lang": "it",
+          "value": "Costruzione"
+        },
+        {
+          "lang": "ja",
+          "value": "建設"
+        },
+        {
+          "lang": "ko",
+          "value": "시공"
+        },
+        {
+          "lang": "lo",
+          "value": "ການກໍ່ສ້າງ"
+        },
+        {
+          "lang": "pl",
+          "value": "Konstrukcja"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_35702",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "sw",
+          "value": "kutoa hati"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "certificação"
+        },
+        {
+          "lang": "et",
+          "value": "sertifitseerimine"
+        },
+        {
+          "lang": "fi",
+          "value": "sertifiointi"
+        },
+        {
+          "lang": "sv",
+          "value": "certifiering"
+        },
+        {
+          "lang": "da",
+          "value": "udstedelse af certifikat"
+        },
+        {
+          "lang": "ca",
+          "value": "Certificació"
+        },
+        {
+          "lang": "nl",
+          "value": "certificering"
+        },
+        {
+          "lang": "ru",
+          "value": "сертификация"
+        },
+        {
+          "lang": "ka",
+          "value": "სერტიფიცირება"
+        },
+        {
+          "lang": "ro",
+          "value": "certificare"
+        },
+        {
+          "lang": "ms",
+          "value": "Pensijilan"
+        },
+        {
+          "lang": "tr",
+          "value": "sertifikasyon"
+        },
+        {
+          "lang": "uk",
+          "value": "сертифікація"
+        },
+        {
+          "lang": "zh",
+          "value": "检定"
+        },
+        {
+          "lang": "th",
+          "value": "การรับรอง"
+        },
+        {
+          "lang": "sk",
+          "value": "certifikácia"
+        },
+        {
+          "lang": "ar",
+          "value": "منح الشهادة"
+        },
+        {
+          "lang": "cs",
+          "value": "osvědčení"
+        },
+        {
+          "lang": "de",
+          "value": "Zertifikat"
+        },
+        {
+          "lang": "en",
+          "value": "certification"
+        },
+        {
+          "lang": "es",
+          "value": "Certificación"
+        },
+        {
+          "lang": "fa",
+          "value": "گواهینامه"
+        },
+        {
+          "lang": "fr",
+          "value": "certification"
+        },
+        {
+          "lang": "hi",
+          "value": "प्रमाणीकरण"
+        },
+        {
+          "lang": "hu",
+          "value": "minõsítés"
+        },
+        {
+          "lang": "it",
+          "value": "Certificazione"
+        },
+        {
+          "lang": "ja",
+          "value": "証明、保証"
+        },
+        {
+          "lang": "lo",
+          "value": "ການຢັ້ງຢືນ"
+        },
+        {
+          "lang": "pl",
+          "value": "Certyfikacja"
+        },
+        {
+          "lang": "pt",
+          "value": "certificação"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_3697",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "be",
+          "value": "паляванне"
+        },
+        {
+          "lang": "sw",
+          "value": "uwindaji"
+        },
+        {
+          "lang": "zh",
+          "value": "狩猎"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "caça"
+        },
+        {
+          "lang": "ro",
+          "value": "vânătoare"
+        },
+        {
+          "lang": "nn",
+          "value": "jakt"
+        },
+        {
+          "lang": "el",
+          "value": "κυνήγι"
+        },
+        {
+          "lang": "fi",
+          "value": "metsästys"
+        },
+        {
+          "lang": "nb",
+          "value": "jakt"
+        },
+        {
+          "lang": "sv",
+          "value": "jakt"
+        },
+        {
+          "lang": "da",
+          "value": "jagt"
+        },
+        {
+          "lang": "ka",
+          "value": "ნადირობა"
+        },
+        {
+          "lang": "uk",
+          "value": "мисливство"
+        },
+        {
+          "lang": "te",
+          "value": "వేట"
+        },
+        {
+          "lang": "tr",
+          "value": "avcılık"
+        },
+        {
+          "lang": "th",
+          "value": "การล่าสัตว์"
+        },
+        {
+          "lang": "sk",
+          "value": "lov"
+        },
+        {
+          "lang": "ru",
+          "value": "охота"
+        },
+        {
+          "lang": "pt",
+          "value": "caça"
+        },
+        {
+          "lang": "ar",
+          "value": "صيد"
+        },
+        {
+          "lang": "cs",
+          "value": "lov"
+        },
+        {
+          "lang": "de",
+          "value": "Jagd"
+        },
+        {
+          "lang": "en",
+          "value": "hunting"
+        },
+        {
+          "lang": "es",
+          "value": "Caza"
+        },
+        {
+          "lang": "fa",
+          "value": "شکار"
+        },
+        {
+          "lang": "fr",
+          "value": "chasse"
+        },
+        {
+          "lang": "hi",
+          "value": "आखेट"
+        },
+        {
+          "lang": "hu",
+          "value": "vadászat"
+        },
+        {
+          "lang": "it",
+          "value": "Caccia"
+        },
+        {
+          "lang": "ja",
+          "value": "狩猟"
+        },
+        {
+          "lang": "ko",
+          "value": "사냥"
+        },
+        {
+          "lang": "lo",
+          "value": "ການລ່າສັດ"
+        },
+        {
+          "lang": "pl",
+          "value": "Łowiectwo"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_37343",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "be",
+          "value": "інтэрв'ю"
+        },
+        {
+          "lang": "es",
+          "value": "Entrevista"
+        },
+        {
+          "lang": "sw",
+          "value": "mahojiano"
+        },
+        {
+          "lang": "ro",
+          "value": "interviu"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "entrevista"
+        },
+        {
+          "lang": "fi",
+          "value": "haastattelut"
+        },
+        {
+          "lang": "nb",
+          "value": "intervjuer"
+        },
+        {
+          "lang": "sv",
+          "value": "intervjuer"
+        },
+        {
+          "lang": "ka",
+          "value": "ინტერვიუ"
+        },
+        {
+          "lang": "uk",
+          "value": "інтерв'ю"
+        },
+        {
+          "lang": "te",
+          "value": "మౌఖిక పరీక్షలు"
+        },
+        {
+          "lang": "tr",
+          "value": "ropörtaj"
+        },
+        {
+          "lang": "zh",
+          "value": "访谈"
+        },
+        {
+          "lang": "th",
+          "value": "การสัมภาษณ์"
+        },
+        {
+          "lang": "ar",
+          "value": "مقابلات"
+        },
+        {
+          "lang": "cs",
+          "value": "pohovory"
+        },
+        {
+          "lang": "de",
+          "value": "Interview"
+        },
+        {
+          "lang": "en",
+          "value": "interviews"
+        },
+        {
+          "lang": "fa",
+          "value": "مصاحبه‌‌ها"
+        },
+        {
+          "lang": "fr",
+          "value": "interview"
+        },
+        {
+          "lang": "hi",
+          "value": "साक्षात्कार"
+        },
+        {
+          "lang": "hu",
+          "value": "interjú"
+        },
+        {
+          "lang": "it",
+          "value": "Interviste"
+        },
+        {
+          "lang": "ja",
+          "value": "面接調査"
+        },
+        {
+          "lang": "lo",
+          "value": "ການສຳພາດ"
+        },
+        {
+          "lang": "pl",
+          "value": "Wywiad"
+        },
+        {
+          "lang": "pt",
+          "value": "entrevista"
+        },
+        {
+          "lang": "ru",
+          "value": "интервью"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_37602",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "sw",
+          "value": "ushiriki"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "participação"
+        },
+        {
+          "lang": "ro",
+          "value": "participare"
+        },
+        {
+          "lang": "ka",
+          "value": "მონაწილეობა"
+        },
+        {
+          "lang": "uk",
+          "value": "участь"
+        },
+        {
+          "lang": "tr",
+          "value": "iştirak"
+        },
+        {
+          "lang": "zh",
+          "value": "参与"
+        },
+        {
+          "lang": "th",
+          "value": "การมีส่วนร่วม"
+        },
+        {
+          "lang": "ru",
+          "value": "участие"
+        },
+        {
+          "lang": "pt",
+          "value": "participação"
+        },
+        {
+          "lang": "ar",
+          "value": "مشاركة"
+        },
+        {
+          "lang": "cs",
+          "value": "angažovanost"
+        },
+        {
+          "lang": "de",
+          "value": "Partizipation"
+        },
+        {
+          "lang": "en",
+          "value": "participation"
+        },
+        {
+          "lang": "es",
+          "value": "Participación"
+        },
+        {
+          "lang": "fa",
+          "value": "مشارکت"
+        },
+        {
+          "lang": "fr",
+          "value": "participation"
+        },
+        {
+          "lang": "hi",
+          "value": "हिस्सेदारी / सहभागीयता"
+        },
+        {
+          "lang": "hu",
+          "value": "részvétel"
+        },
+        {
+          "lang": "it",
+          "value": "Partecipazione"
+        },
+        {
+          "lang": "ja",
+          "value": "参加"
+        },
+        {
+          "lang": "ko",
+          "value": "참가"
+        },
+        {
+          "lang": "lo",
+          "value": "ການເຂົ້າຮ່ວມ"
+        },
+        {
+          "lang": "pl",
+          "value": "Uczestnictwo"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_37866",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "sw",
+          "value": "mawasiliano"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "comunicação"
+        },
+        {
+          "lang": "ka",
+          "value": "კავშირგაბმულობა"
+        },
+        {
+          "lang": "el",
+          "value": "επικοινωνία"
+        },
+        {
+          "lang": "ga",
+          "value": "cumarsáid"
+        },
+        {
+          "lang": "nb",
+          "value": "kommunikasjon"
+        },
+        {
+          "lang": "sv",
+          "value": "kommunikation"
+        },
+        {
+          "lang": "da",
+          "value": "kommunikation"
+        },
+        {
+          "lang": "ms",
+          "value": "Komunikasi"
+        },
+        {
+          "lang": "de",
+          "value": "Kommunikation"
+        },
+        {
+          "lang": "tr",
+          "value": "iletişim"
+        },
+        {
+          "lang": "uk",
+          "value": "комунікації"
+        },
+        {
+          "lang": "zh",
+          "value": "传输"
+        },
+        {
+          "lang": "th",
+          "value": "การสื่อสาร"
+        },
+        {
+          "lang": "ar",
+          "value": "الاتصال"
+        },
+        {
+          "lang": "cs",
+          "value": "komunikace"
+        },
+        {
+          "lang": "en",
+          "value": "communication"
+        },
+        {
+          "lang": "es",
+          "value": "Comunicación"
+        },
+        {
+          "lang": "fa",
+          "value": "ارتباط"
+        },
+        {
+          "lang": "fr",
+          "value": "communication"
+        },
+        {
+          "lang": "hi",
+          "value": "संचार"
+        },
+        {
+          "lang": "it",
+          "value": "Comunicazione"
+        },
+        {
+          "lang": "ko",
+          "value": "의사소통"
+        },
+        {
+          "lang": "lo",
+          "value": "ການສືສານ"
+        },
+        {
+          "lang": "pl",
+          "value": "Komunikacja i łączność"
+        },
+        {
+          "lang": "pt",
+          "value": "comunicação"
+        },
+        {
+          "lang": "ru",
+          "value": "коммуникации"
+        },
+        {
+          "lang": "sk",
+          "value": "komunikácia"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_3791",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "sw",
+          "value": "kufanana"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "identificação"
+        },
+        {
+          "lang": "ka",
+          "value": "იდენტიფიცირება"
+        },
+        {
+          "lang": "ro",
+          "value": "identificare"
+        },
+        {
+          "lang": "uk",
+          "value": "ідентифікація"
+        },
+        {
+          "lang": "te",
+          "value": "గుర్తింపు"
+        },
+        {
+          "lang": "tr",
+          "value": "tanımlama"
+        },
+        {
+          "lang": "zh",
+          "value": "鉴定"
+        },
+        {
+          "lang": "th",
+          "value": "การจัดจำแนก"
+        },
+        {
+          "lang": "sk",
+          "value": "identifikácia"
+        },
+        {
+          "lang": "ru",
+          "value": "идентификация"
+        },
+        {
+          "lang": "pt",
+          "value": "identificação"
+        },
+        {
+          "lang": "ar",
+          "value": "تحديد الهوية"
+        },
+        {
+          "lang": "cs",
+          "value": "identifikace"
+        },
+        {
+          "lang": "de",
+          "value": "Identifizierung"
+        },
+        {
+          "lang": "en",
+          "value": "identification"
+        },
+        {
+          "lang": "es",
+          "value": "Identificación"
+        },
+        {
+          "lang": "fa",
+          "value": "شناسایی (گونه)"
+        },
+        {
+          "lang": "fr",
+          "value": "identification"
+        },
+        {
+          "lang": "hi",
+          "value": "पहचान"
+        },
+        {
+          "lang": "hu",
+          "value": "azonosítás"
+        },
+        {
+          "lang": "it",
+          "value": "Identificazione"
+        },
+        {
+          "lang": "ja",
+          "value": "同定"
+        },
+        {
+          "lang": "ko",
+          "value": "동정"
+        },
+        {
+          "lang": "lo",
+          "value": "ການຈຳແນກ"
+        },
+        {
+          "lang": "pl",
+          "value": "Identyfikacja"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_3822",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "ro",
+          "value": "transferuri de venit"
+        },
+        {
+          "lang": "sw",
+          "value": "uhamisho wa mapato"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "transferência de renda"
+        },
+        {
+          "lang": "uk",
+          "value": "перерозподіл доходів"
+        },
+        {
+          "lang": "te",
+          "value": "ఆదాయపు బదిలీలు"
+        },
+        {
+          "lang": "tr",
+          "value": "gelir aktarımı"
+        },
+        {
+          "lang": "zh",
+          "value": "收入转移"
+        },
+        {
+          "lang": "th",
+          "value": "การถ่ายโอนรายได้"
+        },
+        {
+          "lang": "sk",
+          "value": "transfery príjmu"
+        },
+        {
+          "lang": "ru",
+          "value": "перераспределение доходов"
+        },
+        {
+          "lang": "pt",
+          "value": "transferência de rendimentos"
+        },
+        {
+          "lang": "ar",
+          "value": "تحويلات الدخل"
+        },
+        {
+          "lang": "cs",
+          "value": "transfer příjmů"
+        },
+        {
+          "lang": "de",
+          "value": "Einkommensübertragung"
+        },
+        {
+          "lang": "en",
+          "value": "income transfers"
+        },
+        {
+          "lang": "es",
+          "value": "Transferencia del ingreso"
+        },
+        {
+          "lang": "fa",
+          "value": "نقل و انتقالات درآمد"
+        },
+        {
+          "lang": "fr",
+          "value": "transfert des revenus"
+        },
+        {
+          "lang": "hi",
+          "value": "आय स्थानांतरण"
+        },
+        {
+          "lang": "hu",
+          "value": "jövedelemtranszfer"
+        },
+        {
+          "lang": "it",
+          "value": "Trasferimenti di reddito"
+        },
+        {
+          "lang": "ja",
+          "value": "所得移転"
+        },
+        {
+          "lang": "ko",
+          "value": "소득이전"
+        },
+        {
+          "lang": "lo",
+          "value": "ການມອບໂອນລາຍໄດ້"
+        },
+        {
+          "lang": "pl",
+          "value": "Transfer dochodu"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_3894",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "sw",
+          "value": "kukagua"
+        },
+        {
+          "lang": "ar",
+          "value": "تَفْتِيش"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "inspeção"
+        },
+        {
+          "lang": "ro",
+          "value": "inspecție"
+        },
+        {
+          "lang": "uk",
+          "value": "інспектування"
+        },
+        {
+          "lang": "te",
+          "value": "తనిఖీ"
+        },
+        {
+          "lang": "tr",
+          "value": "denetim"
+        },
+        {
+          "lang": "zh",
+          "value": "检验"
+        },
+        {
+          "lang": "th",
+          "value": "การตรวจสอบ"
+        },
+        {
+          "lang": "sk",
+          "value": "inšpekcia"
+        },
+        {
+          "lang": "ru",
+          "value": "инспекция"
+        },
+        {
+          "lang": "ja",
+          "value": "検査"
+        },
+        {
+          "lang": "cs",
+          "value": "inspekce"
+        },
+        {
+          "lang": "de",
+          "value": "Inspektion"
+        },
+        {
+          "lang": "en",
+          "value": "inspection"
+        },
+        {
+          "lang": "es",
+          "value": "Inspección"
+        },
+        {
+          "lang": "fa",
+          "value": "بازرسي"
+        },
+        {
+          "lang": "fr",
+          "value": "inspection"
+        },
+        {
+          "lang": "hi",
+          "value": "निरीक्षण"
+        },
+        {
+          "lang": "hu",
+          "value": "ellenőrzés"
+        },
+        {
+          "lang": "it",
+          "value": "Ispezione"
+        },
+        {
+          "lang": "ko",
+          "value": "검사"
+        },
+        {
+          "lang": "lo",
+          "value": "ການກວດກາ"
+        },
+        {
+          "lang": "pl",
+          "value": "Inspekcja"
+        },
+        {
+          "lang": "pt",
+          "value": "inspecção"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_3900",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "sw",
+          "value": "kutengwa"
+        },
+        {
+          "lang": "ka",
+          "value": "იზოლაცია"
+        },
+        {
+          "lang": "da",
+          "value": "isolering"
+        },
+        {
+          "lang": "nb",
+          "value": "isolering"
+        },
+        {
+          "lang": "ru",
+          "value": "изоляция (техническая)"
+        },
+        {
+          "lang": "uk",
+          "value": "ізолювання"
+        },
+        {
+          "lang": "te",
+          "value": "బంధనం"
+        },
+        {
+          "lang": "tr",
+          "value": "yalıtım"
+        },
+        {
+          "lang": "zh",
+          "value": "绝缘"
+        },
+        {
+          "lang": "th",
+          "value": "การปกคลุมด้วยฉนวน"
+        },
+        {
+          "lang": "sk",
+          "value": "izolácia"
+        },
+        {
+          "lang": "pt",
+          "value": "isolamento (construções)"
+        },
+        {
+          "lang": "ar",
+          "value": "عزل"
+        },
+        {
+          "lang": "cs",
+          "value": "izolace"
+        },
+        {
+          "lang": "de",
+          "value": "Isolierung"
+        },
+        {
+          "lang": "en",
+          "value": "insulation"
+        },
+        {
+          "lang": "es",
+          "value": "Aislación"
+        },
+        {
+          "lang": "fa",
+          "value": "عایق‌بندی"
+        },
+        {
+          "lang": "fr",
+          "value": "isolation"
+        },
+        {
+          "lang": "hi",
+          "value": "रोधन"
+        },
+        {
+          "lang": "hu",
+          "value": "szigetelés"
+        },
+        {
+          "lang": "it",
+          "value": "Isolamento"
+        },
+        {
+          "lang": "ja",
+          "value": "絶縁"
+        },
+        {
+          "lang": "ko",
+          "value": "절연"
+        },
+        {
+          "lang": "lo",
+          "value": "ວັດຖຸທີ່ໃຊ້ເປັນສະນວນ"
+        },
+        {
+          "lang": "pl",
+          "value": "Izolacja"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_3954",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "be",
+          "value": "арашэнне"
+        },
+        {
+          "lang": "sw",
+          "value": "kutia maji"
+        },
+        {
+          "lang": "uk",
+          "value": "зрошення"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "irrigação"
+        },
+        {
+          "lang": "ka",
+          "value": "რწყვა"
+        },
+        {
+          "lang": "ro",
+          "value": "irigație"
+        },
+        {
+          "lang": "nb",
+          "value": "irrigasjon"
+        },
+        {
+          "lang": "te",
+          "value": "నీటి పారుదల"
+        },
+        {
+          "lang": "tr",
+          "value": "sulama"
+        },
+        {
+          "lang": "zh",
+          "value": "灌溉"
+        },
+        {
+          "lang": "th",
+          "value": "การชลประทาน"
+        },
+        {
+          "lang": "sk",
+          "value": "závlaha"
+        },
+        {
+          "lang": "ru",
+          "value": "орошение"
+        },
+        {
+          "lang": "pt",
+          "value": "irrigação"
+        },
+        {
+          "lang": "ar",
+          "value": "ري"
+        },
+        {
+          "lang": "cs",
+          "value": "závlaha"
+        },
+        {
+          "lang": "de",
+          "value": "Bewässerung"
+        },
+        {
+          "lang": "en",
+          "value": "irrigation"
+        },
+        {
+          "lang": "es",
+          "value": "Riego"
+        },
+        {
+          "lang": "fa",
+          "value": "آبیاری"
+        },
+        {
+          "lang": "fr",
+          "value": "irrigation"
+        },
+        {
+          "lang": "hi",
+          "value": "सिंचाई"
+        },
+        {
+          "lang": "hu",
+          "value": "öntözés"
+        },
+        {
+          "lang": "it",
+          "value": "Irrigazione"
+        },
+        {
+          "lang": "ja",
+          "value": "潅漑"
+        },
+        {
+          "lang": "ko",
+          "value": "관개"
+        },
+        {
+          "lang": "lo",
+          "value": "ຊົນລະປະທານ"
+        },
+        {
+          "lang": "pl",
+          "value": "Nawadnianie"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_3c73540e",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "th",
+          "value": "การกำจัดน้ำแข็ง"
+        },
+        {
+          "lang": "ar",
+          "value": "تذويب"
+        },
+        {
+          "lang": "es",
+          "value": "Descongelación"
+        },
+        {
+          "lang": "en",
+          "value": "deicing"
+        },
+        {
+          "lang": "nb",
+          "value": "avising"
+        },
+        {
+          "lang": "sv",
+          "value": "avisning"
+        },
+        {
+          "lang": "tr",
+          "value": "buz çözme"
+        },
+        {
+          "lang": "de",
+          "value": "Enteisung"
+        },
+        {
+          "lang": "ro",
+          "value": "degivrare"
+        },
+        {
+          "lang": "cs",
+          "value": "odmrazování"
+        },
+        {
+          "lang": "ru",
+          "value": "удаление льда"
+        },
+        {
+          "lang": "fr",
+          "value": "dégivrage"
+        },
+        {
+          "lang": "zh",
+          "value": "除冰"
+        },
+        {
+          "lang": "sw",
+          "value": "kuondoa barafu"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "degelo"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_42b93387",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "ar",
+          "value": "ارتباط"
+        },
+        {
+          "lang": "ru",
+          "value": "вовлеченность"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "engajamento"
+        },
+        {
+          "lang": "sw",
+          "value": "ahadi"
+        },
+        {
+          "lang": "it",
+          "value": "Coinvolgimento"
+        },
+        {
+          "lang": "es",
+          "value": "Compromiso"
+        },
+        {
+          "lang": "sv",
+          "value": "engagemang"
+        },
+        {
+          "lang": "nb",
+          "value": "engasjement"
+        },
+        {
+          "lang": "fr",
+          "value": "engagement"
+        },
+        {
+          "lang": "en",
+          "value": "engagement"
+        },
+        {
+          "lang": "tr",
+          "value": "katılım"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_4524",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "be",
+          "value": "тэхнічнае абслугоўванне і рамонт"
+        },
+        {
+          "lang": "ro",
+          "value": "întreținere"
+        },
+        {
+          "lang": "sw",
+          "value": "tegemezo"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "manutenção"
+        },
+        {
+          "lang": "ka",
+          "value": "ტექნიკური მომსახურება"
+        },
+        {
+          "lang": "nb",
+          "value": "vedlikehold"
+        },
+        {
+          "lang": "el",
+          "value": "συντήρηση"
+        },
+        {
+          "lang": "fi",
+          "value": "kunnossapito"
+        },
+        {
+          "lang": "sv",
+          "value": "underhåll"
+        },
+        {
+          "lang": "da",
+          "value": "vedligeholdelse"
+        },
+        {
+          "lang": "ru",
+          "value": "техническое обслуживание и ремонт"
+        },
+        {
+          "lang": "uk",
+          "value": "технічне обслуговування і ремонтування"
+        },
+        {
+          "lang": "tr",
+          "value": "bakım"
+        },
+        {
+          "lang": "zh",
+          "value": "保养"
+        },
+        {
+          "lang": "th",
+          "value": "การบำรุงรักษา"
+        },
+        {
+          "lang": "sk",
+          "value": "údržba"
+        },
+        {
+          "lang": "pt",
+          "value": "manutenção"
+        },
+        {
+          "lang": "ar",
+          "value": "صيانة"
+        },
+        {
+          "lang": "cs",
+          "value": "údržba"
+        },
+        {
+          "lang": "de",
+          "value": "Instandhaltung"
+        },
+        {
+          "lang": "en",
+          "value": "maintenance"
+        },
+        {
+          "lang": "es",
+          "value": "Mantenimiento"
+        },
+        {
+          "lang": "fa",
+          "value": "نگهداری (ساختمان و تجهیزات)"
+        },
+        {
+          "lang": "fr",
+          "value": "entretien"
+        },
+        {
+          "lang": "hi",
+          "value": "मरम्मत,देखरेख"
+        },
+        {
+          "lang": "hu",
+          "value": "karbantartás"
+        },
+        {
+          "lang": "it",
+          "value": "Manutenzione"
+        },
+        {
+          "lang": "ja",
+          "value": "保守管理"
+        },
+        {
+          "lang": "ko",
+          "value": "정비"
+        },
+        {
+          "lang": "lo",
+          "value": "ການບຳລຸງຮັກສາ"
+        },
+        {
+          "lang": "pl",
+          "value": "Konserwacja i utrzymanie"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_4620",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "sw",
+          "value": "masoko"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "comercialização"
+        },
+        {
+          "lang": "ro",
+          "value": "marketing"
+        },
+        {
+          "lang": "ka",
+          "value": "მარკეტინგი"
+        },
+        {
+          "lang": "uk",
+          "value": "маркетинг"
+        },
+        {
+          "lang": "tr",
+          "value": "pazarlama"
+        },
+        {
+          "lang": "zh",
+          "value": "市场营销"
+        },
+        {
+          "lang": "th",
+          "value": "การตลาด"
+        },
+        {
+          "lang": "sk",
+          "value": "marketing"
+        },
+        {
+          "lang": "ru",
+          "value": "маркетинг"
+        },
+        {
+          "lang": "pt",
+          "value": "comercialização"
+        },
+        {
+          "lang": "ar",
+          "value": "تسويق"
+        },
+        {
+          "lang": "cs",
+          "value": "marketing"
+        },
+        {
+          "lang": "de",
+          "value": "Marketing"
+        },
+        {
+          "lang": "en",
+          "value": "marketing"
+        },
+        {
+          "lang": "es",
+          "value": "Mercadeo"
+        },
+        {
+          "lang": "fa",
+          "value": "بازاریابی"
+        },
+        {
+          "lang": "fr",
+          "value": "marketing"
+        },
+        {
+          "lang": "hi",
+          "value": "विपणन"
+        },
+        {
+          "lang": "hu",
+          "value": "marketing"
+        },
+        {
+          "lang": "it",
+          "value": "Commercializzazione"
+        },
+        {
+          "lang": "ja",
+          "value": "マーケティング"
+        },
+        {
+          "lang": "ko",
+          "value": "유통"
+        },
+        {
+          "lang": "lo",
+          "value": "ການຕະຫຼາດ"
+        },
+        {
+          "lang": "pl",
+          "value": "Marketing"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_4668",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "sv",
+          "value": "mätning"
+        },
+        {
+          "lang": "se",
+          "value": "mihtideapmi"
+        },
+        {
+          "lang": "fi",
+          "value": "mittaus"
+        },
+        {
+          "lang": "sw",
+          "value": "kipimo"
+        },
+        {
+          "lang": "nb",
+          "value": "måling"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "medição"
+        },
+        {
+          "lang": "ro",
+          "value": "măsurare"
+        },
+        {
+          "lang": "uk",
+          "value": "вимірювання"
+        },
+        {
+          "lang": "tr",
+          "value": "ölçüm"
+        },
+        {
+          "lang": "th",
+          "value": "การวัด"
+        },
+        {
+          "lang": "sk",
+          "value": "meranie"
+        },
+        {
+          "lang": "ru",
+          "value": "измерение"
+        },
+        {
+          "lang": "pt",
+          "value": "medição"
+        },
+        {
+          "lang": "pl",
+          "value": "Pomiar"
+        },
+        {
+          "lang": "zh",
+          "value": "测量"
+        },
+        {
+          "lang": "cs",
+          "value": "měření"
+        },
+        {
+          "lang": "ar",
+          "value": "قياس"
+        },
+        {
+          "lang": "de",
+          "value": "Messung"
+        },
+        {
+          "lang": "en",
+          "value": "measurement"
+        },
+        {
+          "lang": "es",
+          "value": "Medición"
+        },
+        {
+          "lang": "fa",
+          "value": "اندازه‌گیری"
+        },
+        {
+          "lang": "fr",
+          "value": "mesure (activité)"
+        },
+        {
+          "lang": "hi",
+          "value": "मापन"
+        },
+        {
+          "lang": "hu",
+          "value": "mérés"
+        },
+        {
+          "lang": "it",
+          "value": "Misurazione"
+        },
+        {
+          "lang": "ja",
+          "value": "測定"
+        },
+        {
+          "lang": "ko",
+          "value": "측정"
+        },
+        {
+          "lang": "lo",
+          "value": "ການວັດແທກ"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_4721b818",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "zh",
+          "value": "协导方法"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "facilitação"
+        },
+        {
+          "lang": "es",
+          "value": "Facilitación"
+        },
+        {
+          "lang": "fr",
+          "value": "facilitation"
+        },
+        {
+          "lang": "fi",
+          "value": "fasilitointi"
+        },
+        {
+          "lang": "sv",
+          "value": "facilitering"
+        },
+        {
+          "lang": "tr",
+          "value": "kolaylaştırma"
+        },
+        {
+          "lang": "uk",
+          "value": "спрощення"
+        },
+        {
+          "lang": "de",
+          "value": "Erleichterung"
+        },
+        {
+          "lang": "ru",
+          "value": "упрощение"
+        },
+        {
+          "lang": "it",
+          "value": "Facilitazione"
+        },
+        {
+          "lang": "ro",
+          "value": "facilitare"
+        },
+        {
+          "lang": "cs",
+          "value": "facilitace"
+        },
+        {
+          "lang": "ar",
+          "value": "تيسير"
+        },
+        {
+          "lang": "sw",
+          "value": "rahisisha"
+        },
+        {
+          "lang": "en",
+          "value": "facilitation"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_487829e6",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "th",
+          "value": "การระงับข้อพิพาท"
+        },
+        {
+          "lang": "be",
+          "value": "вырашэнне спрэчак"
+        },
+        {
+          "lang": "pl",
+          "value": "Rozstrzyganie sporów"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "solução de disputa"
+        },
+        {
+          "lang": "sw",
+          "value": "usuluhishi wa migogoro"
+        },
+        {
+          "lang": "ka",
+          "value": "დავის მოგვარება"
+        },
+        {
+          "lang": "tr",
+          "value": "anlaşmazlıkları çözme"
+        },
+        {
+          "lang": "ru",
+          "value": "разрешение споров"
+        },
+        {
+          "lang": "et",
+          "value": "vaidluste lahendamin"
+        },
+        {
+          "lang": "sr",
+          "value": "решавање спорова"
+        },
+        {
+          "lang": "cs",
+          "value": "řešení sporů"
+        },
+        {
+          "lang": "en",
+          "value": "dispute settlement"
+        },
+        {
+          "lang": "ar",
+          "value": "تسوية النزاعات"
+        },
+        {
+          "lang": "es",
+          "value": "Solución de controversias"
+        },
+        {
+          "lang": "fr",
+          "value": "règlement des différends"
+        },
+        {
+          "lang": "zh",
+          "value": "争端解决"
+        },
+        {
+          "lang": "sv",
+          "value": "tvistlösning"
+        },
+        {
+          "lang": "sq",
+          "value": "zgjidhje e mosmarrëveshjeve"
+        },
+        {
+          "lang": "da",
+          "value": "bilæggelse af tvister"
+        },
+        {
+          "lang": "de",
+          "value": "Beilegung der Streitigkeiten"
+        },
+        {
+          "lang": "hr",
+          "value": "rješavanje sporova"
+        },
+        {
+          "lang": "it",
+          "value": "Composizione delle controversie"
+        },
+        {
+          "lang": "el",
+          "value": "διευθέτηση των διαφορών"
+        },
+        {
+          "lang": "pt",
+          "value": "resolução de diferendos"
+        },
+        {
+          "lang": "fi",
+          "value": "riitojen ratkaiseminen"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_4911",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "ro",
+          "value": "monitorizare"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "vigilância"
+        },
+        {
+          "lang": "sw",
+          "value": "ufuatiliaji"
+        },
+        {
+          "lang": "ka",
+          "value": "მონიტორინგი"
+        },
+        {
+          "lang": "uk",
+          "value": "моніторинг"
+        },
+        {
+          "lang": "tr",
+          "value": "izleme"
+        },
+        {
+          "lang": "zh",
+          "value": "监测"
+        },
+        {
+          "lang": "th",
+          "value": "การติดตามผล"
+        },
+        {
+          "lang": "sk",
+          "value": "monitoring"
+        },
+        {
+          "lang": "ru",
+          "value": "мониторинг"
+        },
+        {
+          "lang": "pt",
+          "value": "vigilância"
+        },
+        {
+          "lang": "ar",
+          "value": "رصد"
+        },
+        {
+          "lang": "cs",
+          "value": "monitorování"
+        },
+        {
+          "lang": "de",
+          "value": "Monitoring"
+        },
+        {
+          "lang": "en",
+          "value": "monitoring"
+        },
+        {
+          "lang": "es",
+          "value": "Vigilancia"
+        },
+        {
+          "lang": "fa",
+          "value": "پایش"
+        },
+        {
+          "lang": "fr",
+          "value": "surveillance"
+        },
+        {
+          "lang": "hi",
+          "value": "नियन्त्रण करना"
+        },
+        {
+          "lang": "hu",
+          "value": "monitoring"
+        },
+        {
+          "lang": "it",
+          "value": "Monitoraggio"
+        },
+        {
+          "lang": "ja",
+          "value": "モニタリング"
+        },
+        {
+          "lang": "ko",
+          "value": "모니터링"
+        },
+        {
+          "lang": "lo",
+          "value": "ການຕິດຕາມ"
+        },
+        {
+          "lang": "pl",
+          "value": "Monitoring"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_49902",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "th",
+          "value": "การปรับปรุงพันธุ์"
+        },
+        {
+          "lang": "sr",
+          "value": "оплемењивање"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "reprodução"
+        },
+        {
+          "lang": "vi",
+          "value": "nhân giống"
+        },
+        {
+          "lang": "sw",
+          "value": "kuzaliana"
+        },
+        {
+          "lang": "it",
+          "value": "Miglioramento genetico"
+        },
+        {
+          "lang": "ko",
+          "value": "육종"
+        },
+        {
+          "lang": "ar",
+          "value": "تربية"
+        },
+        {
+          "lang": "cs",
+          "value": "šlechtění"
+        },
+        {
+          "lang": "en",
+          "value": "breeding"
+        },
+        {
+          "lang": "es",
+          "value": "Mejora"
+        },
+        {
+          "lang": "fr",
+          "value": "amélioration génétique"
+        },
+        {
+          "lang": "zh",
+          "value": "育种"
+        },
+        {
+          "lang": "uk",
+          "value": "селекція і розведення"
+        },
+        {
+          "lang": "tr",
+          "value": "ıslah"
+        },
+        {
+          "lang": "de",
+          "value": "Züchtung"
+        },
+        {
+          "lang": "ms",
+          "value": "Pembiakan"
+        },
+        {
+          "lang": "te",
+          "value": "ప్రజననం"
+        },
+        {
+          "lang": "ru",
+          "value": "селекция и разведение"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_49928",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "th",
+          "value": "การวิเคราะห์"
+        },
+        {
+          "lang": "pt",
+          "value": "análise"
+        },
+        {
+          "lang": "da",
+          "value": "analyse"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "análise"
+        },
+        {
+          "lang": "be",
+          "value": "аналіз"
+        },
+        {
+          "lang": "sw",
+          "value": "uchambuzi"
+        },
+        {
+          "lang": "ar",
+          "value": "تَحْلِيل"
+        },
+        {
+          "lang": "et",
+          "value": "analüüs"
+        },
+        {
+          "lang": "sr",
+          "value": "анализа"
+        },
+        {
+          "lang": "fi",
+          "value": "analyysi"
+        },
+        {
+          "lang": "nl",
+          "value": "analyse"
+        },
+        {
+          "lang": "nb",
+          "value": "analyse"
+        },
+        {
+          "lang": "sv",
+          "value": "analys"
+        },
+        {
+          "lang": "cs",
+          "value": "analýza"
+        },
+        {
+          "lang": "en",
+          "value": "analysis"
+        },
+        {
+          "lang": "es",
+          "value": "Análisis"
+        },
+        {
+          "lang": "fr",
+          "value": "analyse"
+        },
+        {
+          "lang": "ko",
+          "value": "분석"
+        },
+        {
+          "lang": "ru",
+          "value": "анализ"
+        },
+        {
+          "lang": "zh",
+          "value": "分析"
+        },
+        {
+          "lang": "uk",
+          "value": "аналіз"
+        },
+        {
+          "lang": "tr",
+          "value": "analiz"
+        },
+        {
+          "lang": "de",
+          "value": "Analyse"
+        },
+        {
+          "lang": "it",
+          "value": "Analisi"
+        },
+        {
+          "lang": "ms",
+          "value": "Analisis"
+        },
+        {
+          "lang": "ka",
+          "value": "ანალიზი"
+        },
+        {
+          "lang": "ro",
+          "value": "analiză"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_4bde1dcc",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "th",
+          "value": "การปรับแก้ค่า"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "correção"
+        },
+        {
+          "lang": "tr",
+          "value": "düzeltme"
+        },
+        {
+          "lang": "en",
+          "value": "corrections"
+        },
+        {
+          "lang": "es",
+          "value": "Corrección"
+        },
+        {
+          "lang": "fr",
+          "value": "correction"
+        },
+        {
+          "lang": "cs",
+          "value": "korekce"
+        },
+        {
+          "lang": "de",
+          "value": "Korrektur"
+        },
+        {
+          "lang": "da",
+          "value": "korrektioner"
+        },
+        {
+          "lang": "nb",
+          "value": "korreksjoner"
+        },
+        {
+          "lang": "sw",
+          "value": "masahihisho"
+        },
+        {
+          "lang": "zh",
+          "value": "改正"
+        },
+        {
+          "lang": "be",
+          "value": "выпраўленне"
+        },
+        {
+          "lang": "ar",
+          "value": "تصحيحات"
+        },
+        {
+          "lang": "ru",
+          "value": "поправки"
+        },
+        {
+          "lang": "sv",
+          "value": "korrigeringar"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_50119",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "th",
+          "value": "การคำนวณ"
+        },
+        {
+          "lang": "zh",
+          "value": "计算"
+        },
+        {
+          "lang": "ka",
+          "value": "გამოანგარიშება"
+        },
+        {
+          "lang": "sw",
+          "value": "ukokotozi"
+        },
+        {
+          "lang": "ar",
+          "value": "حساب"
+        },
+        {
+          "lang": "cs",
+          "value": "výpočet"
+        },
+        {
+          "lang": "en",
+          "value": "calculation"
+        },
+        {
+          "lang": "es",
+          "value": "Cálculo"
+        },
+        {
+          "lang": "fr",
+          "value": "calcul"
+        },
+        {
+          "lang": "ko",
+          "value": "연산"
+        },
+        {
+          "lang": "pt",
+          "value": "cálculo"
+        },
+        {
+          "lang": "uk",
+          "value": "розрахунок"
+        },
+        {
+          "lang": "tr",
+          "value": "hesaplama"
+        },
+        {
+          "lang": "de",
+          "value": "Berechnung"
+        },
+        {
+          "lang": "ms",
+          "value": "Pengiraan"
+        },
+        {
+          "lang": "it",
+          "value": "Calcolo"
+        },
+        {
+          "lang": "ro",
+          "value": "calcul"
+        },
+        {
+          "lang": "ru",
+          "value": "расчет"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "cálculo"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_50345",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "zh",
+          "value": "勘探地质条件"
+        },
+        {
+          "lang": "sw",
+          "value": "utafutaji wa madini"
+        },
+        {
+          "lang": "cs",
+          "value": "pátrání"
+        },
+        {
+          "lang": "en",
+          "value": "prospecting"
+        },
+        {
+          "lang": "es",
+          "value": "Prospección"
+        },
+        {
+          "lang": "fr",
+          "value": "prospection"
+        },
+        {
+          "lang": "ko",
+          "value": "탐광"
+        },
+        {
+          "lang": "pt",
+          "value": "prospecção"
+        },
+        {
+          "lang": "ru",
+          "value": "разведка"
+        },
+        {
+          "lang": "de",
+          "value": "Prospektion"
+        },
+        {
+          "lang": "tr",
+          "value": "prospeksiyon"
+        },
+        {
+          "lang": "it",
+          "value": "Prospezione"
+        },
+        {
+          "lang": "uk",
+          "value": "пошуково-розвідувальні роботи"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "prospecção"
+        },
+        {
+          "lang": "ar",
+          "value": "تنقيب"
+        },
+        {
+          "lang": "sr",
+          "value": "проспекција"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_50bccb82",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "sw",
+          "value": "uokoaji"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "evacuação"
+        },
+        {
+          "lang": "be",
+          "value": "эвакуацыя"
+        },
+        {
+          "lang": "en",
+          "value": "evacuation"
+        },
+        {
+          "lang": "nb",
+          "value": "evakuering"
+        },
+        {
+          "lang": "sv",
+          "value": "evakuering"
+        },
+        {
+          "lang": "fi",
+          "value": "evakuointi"
+        },
+        {
+          "lang": "zh",
+          "value": "撤离"
+        },
+        {
+          "lang": "ar",
+          "value": "الإجلاء"
+        },
+        {
+          "lang": "ru",
+          "value": "эвакуация"
+        },
+        {
+          "lang": "es",
+          "value": "Evacuación"
+        },
+        {
+          "lang": "fr",
+          "value": "évacuation"
+        },
+        {
+          "lang": "tr",
+          "value": "acil tahliye"
+        },
+        {
+          "lang": "ka",
+          "value": "ევაკუაცია"
+        },
+        {
+          "lang": "ro",
+          "value": "evacuare"
+        },
+        {
+          "lang": "it",
+          "value": "Evacuazione"
+        },
+        {
+          "lang": "de",
+          "value": "Evakuierung"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_50c7fa97",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "th",
+          "value": "การขุดลอก"
+        },
+        {
+          "lang": "ro",
+          "value": "dragare"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "dragagem"
+        },
+        {
+          "lang": "sw",
+          "value": "nyunyiziaji"
+        },
+        {
+          "lang": "ar",
+          "value": "تكريك"
+        },
+        {
+          "lang": "uk",
+          "value": "днопоглиблення"
+        },
+        {
+          "lang": "es",
+          "value": "Dragado (sedimento)"
+        },
+        {
+          "lang": "cs",
+          "value": "bagrování"
+        },
+        {
+          "lang": "tr",
+          "value": "tarama"
+        },
+        {
+          "lang": "de",
+          "value": "Ausbaggern"
+        },
+        {
+          "lang": "zh",
+          "value": "挖泥"
+        },
+        {
+          "lang": "ru",
+          "value": "драгировка"
+        },
+        {
+          "lang": "fr",
+          "value": "curage"
+        },
+        {
+          "lang": "en",
+          "value": "dredging"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_5495",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "be",
+          "value": "пакаванне"
+        },
+        {
+          "lang": "ka",
+          "value": "შეფუთვა"
+        },
+        {
+          "lang": "sw",
+          "value": "vifungashio"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "acondicionamento"
+        },
+        {
+          "lang": "ro",
+          "value": "ambalare"
+        },
+        {
+          "lang": "uk",
+          "value": "пакування"
+        },
+        {
+          "lang": "ms",
+          "value": "Pembungkusan"
+        },
+        {
+          "lang": "tr",
+          "value": "ambalajlama"
+        },
+        {
+          "lang": "zh",
+          "value": "包装"
+        },
+        {
+          "lang": "th",
+          "value": "การบรรจุหีบห่อ"
+        },
+        {
+          "lang": "sk",
+          "value": "balenie"
+        },
+        {
+          "lang": "ru",
+          "value": "упаковка"
+        },
+        {
+          "lang": "pt",
+          "value": "acondicionamento"
+        },
+        {
+          "lang": "ar",
+          "value": "تعبئة وتغليف"
+        },
+        {
+          "lang": "cs",
+          "value": "obalová technika"
+        },
+        {
+          "lang": "de",
+          "value": "Verpacken"
+        },
+        {
+          "lang": "en",
+          "value": "packaging"
+        },
+        {
+          "lang": "es",
+          "value": "Empaquetado"
+        },
+        {
+          "lang": "fa",
+          "value": "بسته‌بندی"
+        },
+        {
+          "lang": "fr",
+          "value": "conditionnement"
+        },
+        {
+          "lang": "hi",
+          "value": "प्रतिपादम"
+        },
+        {
+          "lang": "hu",
+          "value": "csomagolás"
+        },
+        {
+          "lang": "it",
+          "value": "Confezionamento"
+        },
+        {
+          "lang": "ja",
+          "value": "包装"
+        },
+        {
+          "lang": "ko",
+          "value": "포장"
+        },
+        {
+          "lang": "lo",
+          "value": "ການຫຸ້ມຫໍ່"
+        },
+        {
+          "lang": "pl",
+          "value": "Pakowanie"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_5828",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "be",
+          "value": "фізічная актыўнасць"
+        },
+        {
+          "lang": "sw",
+          "value": "shughuli za mwili"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "atividade física"
+        },
+        {
+          "lang": "ro",
+          "value": "activitate fizică"
+        },
+        {
+          "lang": "fi",
+          "value": "fyysinen aktiivisuus"
+        },
+        {
+          "lang": "sv",
+          "value": "fysisk aktivitet"
+        },
+        {
+          "lang": "nb",
+          "value": "fysisk aktivitet"
+        },
+        {
+          "lang": "da",
+          "value": "fysisk aktivitet"
+        },
+        {
+          "lang": "vi",
+          "value": "hoạt động thể chất"
+        },
+        {
+          "lang": "el",
+          "value": "Σωματική δραστηριότητα"
+        },
+        {
+          "lang": "uk",
+          "value": "фізична активність"
+        },
+        {
+          "lang": "te",
+          "value": "వ్యాయామం"
+        },
+        {
+          "lang": "tr",
+          "value": "fiziksel aktivite"
+        },
+        {
+          "lang": "zh",
+          "value": "体力活动"
+        },
+        {
+          "lang": "th",
+          "value": "กิจกรรมทางกาย"
+        },
+        {
+          "lang": "sk",
+          "value": "telesná aktivita"
+        },
+        {
+          "lang": "ru",
+          "value": "физическая активность"
+        },
+        {
+          "lang": "pt",
+          "value": "actividade física"
+        },
+        {
+          "lang": "ja",
+          "value": "運動"
+        },
+        {
+          "lang": "ar",
+          "value": "نشاط جسدي"
+        },
+        {
+          "lang": "cs",
+          "value": "tělesná aktivita"
+        },
+        {
+          "lang": "de",
+          "value": "körperliche Betätigung"
+        },
+        {
+          "lang": "en",
+          "value": "physical activity"
+        },
+        {
+          "lang": "es",
+          "value": "Actividad física"
+        },
+        {
+          "lang": "fa",
+          "value": "فعالیت فیزیکی"
+        },
+        {
+          "lang": "fr",
+          "value": "activité physique"
+        },
+        {
+          "lang": "hi",
+          "value": "भौतिक / शारीरिक क्रियाकलाप"
+        },
+        {
+          "lang": "hu",
+          "value": "fizikai aktivitás"
+        },
+        {
+          "lang": "it",
+          "value": "Attività fisica"
+        },
+        {
+          "lang": "ko",
+          "value": "신체활동"
+        },
+        {
+          "lang": "lo",
+          "value": "ກິດຈະກຳທາງກາຍ"
+        },
+        {
+          "lang": "pl",
+          "value": "Aktywność fizyczna"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_5951",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "sw",
+          "value": "kupanga"
+        },
+        {
+          "lang": "be",
+          "value": "планаванне"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "planejamento"
+        },
+        {
+          "lang": "ro",
+          "value": "planificare"
+        },
+        {
+          "lang": "ka",
+          "value": "დაგეგმვა"
+        },
+        {
+          "lang": "uk",
+          "value": "планування"
+        },
+        {
+          "lang": "tr",
+          "value": "planlama"
+        },
+        {
+          "lang": "zh",
+          "value": "规划"
+        },
+        {
+          "lang": "th",
+          "value": "การวางแผน"
+        },
+        {
+          "lang": "sk",
+          "value": "plánovanie"
+        },
+        {
+          "lang": "ru",
+          "value": "планирование"
+        },
+        {
+          "lang": "pt",
+          "value": "planeamento"
+        },
+        {
+          "lang": "ar",
+          "value": "تخطيط"
+        },
+        {
+          "lang": "cs",
+          "value": "plánování"
+        },
+        {
+          "lang": "de",
+          "value": "Planung"
+        },
+        {
+          "lang": "en",
+          "value": "planning"
+        },
+        {
+          "lang": "es",
+          "value": "Planificación"
+        },
+        {
+          "lang": "fa",
+          "value": "برنامه‌ریزی"
+        },
+        {
+          "lang": "fr",
+          "value": "planification"
+        },
+        {
+          "lang": "hi",
+          "value": "योजना बनाना"
+        },
+        {
+          "lang": "hu",
+          "value": "tervezés"
+        },
+        {
+          "lang": "it",
+          "value": "Pianificazione"
+        },
+        {
+          "lang": "ja",
+          "value": "計画"
+        },
+        {
+          "lang": "ko",
+          "value": "계획"
+        },
+        {
+          "lang": "lo",
+          "value": "ການວາງແຜນ"
+        },
+        {
+          "lang": "pl",
+          "value": "Planowanie"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_5965",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "sr",
+          "value": "оснивање постројења"
+        },
+        {
+          "lang": "be",
+          "value": "закладка пасеваў"
+        },
+        {
+          "lang": "sw",
+          "value": "kuanzisha mimea"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "estabelecimento da planta"
+        },
+        {
+          "lang": "ro",
+          "value": "instalarea plantelor"
+        },
+        {
+          "lang": "tr",
+          "value": "bitki tesisi"
+        },
+        {
+          "lang": "zh",
+          "value": "植物定植"
+        },
+        {
+          "lang": "th",
+          "value": "การตั้งตัวของพืช"
+        },
+        {
+          "lang": "sk",
+          "value": "založenie porastu"
+        },
+        {
+          "lang": "ru",
+          "value": "становление растений"
+        },
+        {
+          "lang": "pt",
+          "value": "estabelecimento da planta"
+        },
+        {
+          "lang": "ar",
+          "value": "تكيف النباتات"
+        },
+        {
+          "lang": "cs",
+          "value": "založení porostu"
+        },
+        {
+          "lang": "de",
+          "value": "Pflanzenetablierung"
+        },
+        {
+          "lang": "en",
+          "value": "plant establishment"
+        },
+        {
+          "lang": "es",
+          "value": "Establecimiento de plantas"
+        },
+        {
+          "lang": "fa",
+          "value": "پاگرفتن گیاه"
+        },
+        {
+          "lang": "fr",
+          "value": "établissement de la plante"
+        },
+        {
+          "lang": "hi",
+          "value": "पौध-प्रस्थापना"
+        },
+        {
+          "lang": "hu",
+          "value": "növénytelepítés"
+        },
+        {
+          "lang": "it",
+          "value": "Adattamento ambientale della pianta"
+        },
+        {
+          "lang": "ja",
+          "value": "植物順化"
+        },
+        {
+          "lang": "ko",
+          "value": "식물조성"
+        },
+        {
+          "lang": "lo",
+          "value": "ການສ້າງຕົວຂອງພືດ"
+        },
+        {
+          "lang": "pl",
+          "value": "Zakładanie upraw i drzewostanów"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_5bbac269",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "pt-BR",
+          "value": "ação liderada localmente"
+        },
+        {
+          "lang": "sw",
+          "value": "hatua zinazoongozwa na wenyeji"
+        },
+        {
+          "lang": "th",
+          "value": "การดำเนินงานที่นำโดยท้องถิ่น"
+        },
+        {
+          "lang": "zh",
+          "value": "地方主导的行动"
+        },
+        {
+          "lang": "ru",
+          "value": "действия на местном уровне"
+        },
+        {
+          "lang": "ar",
+          "value": "عمل بقيادة محلية"
+        },
+        {
+          "lang": "fr",
+          "value": "action menée localement"
+        },
+        {
+          "lang": "es",
+          "value": "Acción liderada localmente"
+        },
+        {
+          "lang": "en",
+          "value": "locally-led action"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_6195",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "be",
+          "value": "перапрацоўка"
+        },
+        {
+          "lang": "ka",
+          "value": "გადამუშავება"
+        },
+        {
+          "lang": "sw",
+          "value": "andamana"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "processamento"
+        },
+        {
+          "lang": "it",
+          "value": "Lavorazione"
+        },
+        {
+          "lang": "uk",
+          "value": "перероблення"
+        },
+        {
+          "lang": "ro",
+          "value": "prelucrare"
+        },
+        {
+          "lang": "te",
+          "value": "వ్యవహార ప్రక్రియలు"
+        },
+        {
+          "lang": "tr",
+          "value": "işleme"
+        },
+        {
+          "lang": "zh",
+          "value": "加工"
+        },
+        {
+          "lang": "th",
+          "value": "กระบวนการผลิต"
+        },
+        {
+          "lang": "sk",
+          "value": "spracovanie"
+        },
+        {
+          "lang": "ru",
+          "value": "переработка"
+        },
+        {
+          "lang": "ar",
+          "value": "تجهيز"
+        },
+        {
+          "lang": "cs",
+          "value": "zpracování"
+        },
+        {
+          "lang": "de",
+          "value": "Verarbeitung"
+        },
+        {
+          "lang": "en",
+          "value": "processing"
+        },
+        {
+          "lang": "es",
+          "value": "Procesamiento"
+        },
+        {
+          "lang": "fa",
+          "value": "فراوری"
+        },
+        {
+          "lang": "fr",
+          "value": "traitement"
+        },
+        {
+          "lang": "hi",
+          "value": "संसाधन"
+        },
+        {
+          "lang": "hu",
+          "value": "feldolgozás"
+        },
+        {
+          "lang": "ja",
+          "value": "加工"
+        },
+        {
+          "lang": "ko",
+          "value": "가공"
+        },
+        {
+          "lang": "lo",
+          "value": "ຂະບວນການຜະລິດ"
+        },
+        {
+          "lang": "pl",
+          "value": "Przetwarzanie"
+        },
+        {
+          "lang": "pt",
+          "value": "processamento"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_62",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "sw",
+          "value": "uhasibu"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "contabilidade"
+        },
+        {
+          "lang": "ro",
+          "value": "contabilitate"
+        },
+        {
+          "lang": "ka",
+          "value": "ბუღალტრული აღრიცხვა"
+        },
+        {
+          "lang": "te",
+          "value": "జమా ఖర్చులు రాయడం"
+        },
+        {
+          "lang": "tr",
+          "value": "muhasebe"
+        },
+        {
+          "lang": "uk",
+          "value": "облік"
+        },
+        {
+          "lang": "ms",
+          "value": "Perakaunan"
+        },
+        {
+          "lang": "zh",
+          "value": "会计学"
+        },
+        {
+          "lang": "th",
+          "value": "การบัญชี"
+        },
+        {
+          "lang": "sk",
+          "value": "účtovníctvo"
+        },
+        {
+          "lang": "ru",
+          "value": "учет"
+        },
+        {
+          "lang": "pt",
+          "value": "contabilidade"
+        },
+        {
+          "lang": "ar",
+          "value": "محاسبة"
+        },
+        {
+          "lang": "cs",
+          "value": "účetnictví"
+        },
+        {
+          "lang": "de",
+          "value": "Buchführung"
+        },
+        {
+          "lang": "en",
+          "value": "accounting"
+        },
+        {
+          "lang": "es",
+          "value": "Contabilidad"
+        },
+        {
+          "lang": "fa",
+          "value": "حسابداری"
+        },
+        {
+          "lang": "fr",
+          "value": "comptabilité"
+        },
+        {
+          "lang": "hi",
+          "value": "लेखांकन / लेखाशास्त्र"
+        },
+        {
+          "lang": "hu",
+          "value": "könyvelés"
+        },
+        {
+          "lang": "it",
+          "value": "Contabilità"
+        },
+        {
+          "lang": "ja",
+          "value": "会計"
+        },
+        {
+          "lang": "ko",
+          "value": "회계"
+        },
+        {
+          "lang": "lo",
+          "value": "ການບັນຊີ"
+        },
+        {
+          "lang": "pl",
+          "value": "Rachunkowość"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_6200",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "sv",
+          "value": "produktion"
+        },
+        {
+          "lang": "nn",
+          "value": "produksjon"
+        },
+        {
+          "lang": "nl",
+          "value": "productie"
+        },
+        {
+          "lang": "fi",
+          "value": "tuotanto"
+        },
+        {
+          "lang": "da",
+          "value": "produktion"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "produção"
+        },
+        {
+          "lang": "sw",
+          "value": "uzalishaji"
+        },
+        {
+          "lang": "nb",
+          "value": "produksjon"
+        },
+        {
+          "lang": "ka",
+          "value": "წარმოება"
+        },
+        {
+          "lang": "ro",
+          "value": "producţie"
+        },
+        {
+          "lang": "uk",
+          "value": "виробництво"
+        },
+        {
+          "lang": "tr",
+          "value": "üretim"
+        },
+        {
+          "lang": "zh",
+          "value": "生产"
+        },
+        {
+          "lang": "th",
+          "value": "การผลิต"
+        },
+        {
+          "lang": "sk",
+          "value": "výroba"
+        },
+        {
+          "lang": "ru",
+          "value": "производство"
+        },
+        {
+          "lang": "pt",
+          "value": "produção"
+        },
+        {
+          "lang": "ar",
+          "value": "إنتاج"
+        },
+        {
+          "lang": "cs",
+          "value": "výroba"
+        },
+        {
+          "lang": "de",
+          "value": "Produktion"
+        },
+        {
+          "lang": "en",
+          "value": "production"
+        },
+        {
+          "lang": "es",
+          "value": "Producción"
+        },
+        {
+          "lang": "fa",
+          "value": "تولید"
+        },
+        {
+          "lang": "fr",
+          "value": "production"
+        },
+        {
+          "lang": "hi",
+          "value": "उत्पादन"
+        },
+        {
+          "lang": "hu",
+          "value": "termelés"
+        },
+        {
+          "lang": "it",
+          "value": "Produzione"
+        },
+        {
+          "lang": "ja",
+          "value": "生産"
+        },
+        {
+          "lang": "ko",
+          "value": "생산"
+        },
+        {
+          "lang": "lo",
+          "value": "ການຜະລິດ"
+        },
+        {
+          "lang": "pl",
+          "value": "Produkcja"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_6220",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "be",
+          "value": "камп'ютарнае праграмаванне"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "programação de computador"
+        },
+        {
+          "lang": "sw",
+          "value": "utayarishaji wa kompyuta"
+        },
+        {
+          "lang": "ka",
+          "value": "კომპიუტერული დაპროგრამება"
+        },
+        {
+          "lang": "ar",
+          "value": "برمجة الحاسوب"
+        },
+        {
+          "lang": "ms",
+          "value": "Pengaturcaraan komputer"
+        },
+        {
+          "lang": "uk",
+          "value": "комп'ютерне програмування"
+        },
+        {
+          "lang": "tr",
+          "value": "bilgisayar programlama"
+        },
+        {
+          "lang": "zh",
+          "value": "计算机程序设计"
+        },
+        {
+          "lang": "th",
+          "value": "การทำโปรแกรมคอมพิวเตอร์"
+        },
+        {
+          "lang": "sk",
+          "value": "programovanie"
+        },
+        {
+          "lang": "ru",
+          "value": "компьютерное программирование"
+        },
+        {
+          "lang": "cs",
+          "value": "programování"
+        },
+        {
+          "lang": "de",
+          "value": "Computer Programmieren"
+        },
+        {
+          "lang": "en",
+          "value": "computer programming"
+        },
+        {
+          "lang": "es",
+          "value": "Programación informática"
+        },
+        {
+          "lang": "fa",
+          "value": "برنامه‌نويسي رايانه‌اي"
+        },
+        {
+          "lang": "fr",
+          "value": "programmation informatique"
+        },
+        {
+          "lang": "hi",
+          "value": "कम्प्यूटर/संगणक प्रोग्रामिंग"
+        },
+        {
+          "lang": "hu",
+          "value": "számítógép-programozás"
+        },
+        {
+          "lang": "it",
+          "value": "Programmazione dell'elaboratore"
+        },
+        {
+          "lang": "ja",
+          "value": "電算機プログラミング"
+        },
+        {
+          "lang": "ko",
+          "value": "컴퓨터프로그래밍"
+        },
+        {
+          "lang": "lo",
+          "value": "ຄອມພິວເຕີໂປແກມມິງ"
+        },
+        {
+          "lang": "pl",
+          "value": "Programowanie komputerów"
+        },
+        {
+          "lang": "pt",
+          "value": "programação informática"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_6352",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "be",
+          "value": "сувязі з грамадскасцю"
+        },
+        {
+          "lang": "es",
+          "value": "Relación pública"
+        },
+        {
+          "lang": "sw",
+          "value": "mahusiano ya umma"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "relações públicas"
+        },
+        {
+          "lang": "ka",
+          "value": "საზოგადოებრივი ურთიერთობები"
+        },
+        {
+          "lang": "ro",
+          "value": "relații cu publicul"
+        },
+        {
+          "lang": "tr",
+          "value": "halkla ilişkiler"
+        },
+        {
+          "lang": "zh",
+          "value": "公共关系"
+        },
+        {
+          "lang": "th",
+          "value": "การประชาสัมพันธ์"
+        },
+        {
+          "lang": "sk",
+          "value": "styk s verejnosťou"
+        },
+        {
+          "lang": "ru",
+          "value": "общественные связи"
+        },
+        {
+          "lang": "ar",
+          "value": "علاقات عامة"
+        },
+        {
+          "lang": "cs",
+          "value": "styk s veřejností"
+        },
+        {
+          "lang": "de",
+          "value": "Öffentlichkeitsarbeit"
+        },
+        {
+          "lang": "en",
+          "value": "public relations"
+        },
+        {
+          "lang": "fa",
+          "value": "روابط عمومی"
+        },
+        {
+          "lang": "fr",
+          "value": "relations publiques"
+        },
+        {
+          "lang": "hi",
+          "value": "लोक सम्बन्ध"
+        },
+        {
+          "lang": "hu",
+          "value": "közönségkapcsolat"
+        },
+        {
+          "lang": "it",
+          "value": "Relazioni pubbliche"
+        },
+        {
+          "lang": "ja",
+          "value": "広報活動"
+        },
+        {
+          "lang": "ko",
+          "value": "공보"
+        },
+        {
+          "lang": "lo",
+          "value": "ການປະຊາສຳພັນ"
+        },
+        {
+          "lang": "pl",
+          "value": "Kreowanie wizerunku firmy"
+        },
+        {
+          "lang": "pt",
+          "value": "relações públicas"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_6477",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "pt-BR",
+          "value": "recreação"
+        },
+        {
+          "lang": "sw",
+          "value": "burudani"
+        },
+        {
+          "lang": "ro",
+          "value": "recreare"
+        },
+        {
+          "lang": "et",
+          "value": "rekreatsioon"
+        },
+        {
+          "lang": "ka",
+          "value": "რეკრეაცია"
+        },
+        {
+          "lang": "uk",
+          "value": "відпочинок"
+        },
+        {
+          "lang": "tr",
+          "value": "rekreasyon"
+        },
+        {
+          "lang": "zh",
+          "value": "休闲"
+        },
+        {
+          "lang": "th",
+          "value": "นันทนาการ"
+        },
+        {
+          "lang": "sk",
+          "value": "rekreácia"
+        },
+        {
+          "lang": "pt",
+          "value": "divertimento"
+        },
+        {
+          "lang": "pl",
+          "value": "Rekreacja"
+        },
+        {
+          "lang": "ru",
+          "value": "отдых"
+        },
+        {
+          "lang": "ar",
+          "value": "استجمام"
+        },
+        {
+          "lang": "cs",
+          "value": "rekreace"
+        },
+        {
+          "lang": "de",
+          "value": "Erholung"
+        },
+        {
+          "lang": "en",
+          "value": "recreation"
+        },
+        {
+          "lang": "es",
+          "value": "Recreación"
+        },
+        {
+          "lang": "fa",
+          "value": "تفریح"
+        },
+        {
+          "lang": "fr",
+          "value": "loisir"
+        },
+        {
+          "lang": "hi",
+          "value": "मनोरंजन"
+        },
+        {
+          "lang": "hu",
+          "value": "rekreáció"
+        },
+        {
+          "lang": "it",
+          "value": "Ricreazione"
+        },
+        {
+          "lang": "ja",
+          "value": "レクリエーション"
+        },
+        {
+          "lang": "ko",
+          "value": "휴양"
+        },
+        {
+          "lang": "lo",
+          "value": "ການພັກຜ່ອນຢ່ອນໃຈ"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_6513",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "ka",
+          "value": "კვლევა"
+        },
+        {
+          "lang": "nn",
+          "value": "forsking"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "investigação"
+        },
+        {
+          "lang": "sw",
+          "value": "utafiti"
+        },
+        {
+          "lang": "nb",
+          "value": "forskning"
+        },
+        {
+          "lang": "ro",
+          "value": "cercetare"
+        },
+        {
+          "lang": "my",
+          "value": "သုတေသန"
+        },
+        {
+          "lang": "vi",
+          "value": "nghiên cứu"
+        },
+        {
+          "lang": "km",
+          "value": "ការស្រាវជ្រាវ"
+        },
+        {
+          "lang": "uk",
+          "value": "дослідження"
+        },
+        {
+          "lang": "tr",
+          "value": "araştırma"
+        },
+        {
+          "lang": "zh",
+          "value": "研究"
+        },
+        {
+          "lang": "th",
+          "value": "การวิจัย"
+        },
+        {
+          "lang": "sk",
+          "value": "výskum"
+        },
+        {
+          "lang": "ru",
+          "value": "исследования"
+        },
+        {
+          "lang": "pt",
+          "value": "investigação"
+        },
+        {
+          "lang": "ar",
+          "value": "بحث"
+        },
+        {
+          "lang": "cs",
+          "value": "výzkum"
+        },
+        {
+          "lang": "de",
+          "value": "Forschung"
+        },
+        {
+          "lang": "en",
+          "value": "research"
+        },
+        {
+          "lang": "es",
+          "value": "Investigación"
+        },
+        {
+          "lang": "fa",
+          "value": "پژوهش"
+        },
+        {
+          "lang": "fr",
+          "value": "recherche"
+        },
+        {
+          "lang": "hi",
+          "value": "शोध"
+        },
+        {
+          "lang": "hu",
+          "value": "kutatás"
+        },
+        {
+          "lang": "it",
+          "value": "Ricerca"
+        },
+        {
+          "lang": "ja",
+          "value": "研究"
+        },
+        {
+          "lang": "ko",
+          "value": "연구"
+        },
+        {
+          "lang": "lo",
+          "value": "ການຄົ້ນຄວ້າ"
+        },
+        {
+          "lang": "pl",
+          "value": "Badanie naukowe"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_6940",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "be",
+          "value": "апрацоўка насення"
+        },
+        {
+          "lang": "sw",
+          "value": "matibabu ya mbegu"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "tratamento de sementes"
+        },
+        {
+          "lang": "ro",
+          "value": "tratarea semințelor"
+        },
+        {
+          "lang": "uk",
+          "value": "обробка насіння"
+        },
+        {
+          "lang": "tr",
+          "value": "tohumluk işleme"
+        },
+        {
+          "lang": "zh",
+          "value": "种子处理"
+        },
+        {
+          "lang": "th",
+          "value": "ซีดทรีทเมนท์"
+        },
+        {
+          "lang": "sk",
+          "value": "úprava osiva"
+        },
+        {
+          "lang": "ru",
+          "value": "обработка семян"
+        },
+        {
+          "lang": "pt",
+          "value": "tratamento de sementes"
+        },
+        {
+          "lang": "ar",
+          "value": "معالجة البذور"
+        },
+        {
+          "lang": "cs",
+          "value": "úprava osiva"
+        },
+        {
+          "lang": "de",
+          "value": "Saatgutbehandlung"
+        },
+        {
+          "lang": "en",
+          "value": "seed treatment"
+        },
+        {
+          "lang": "es",
+          "value": "Tratamiento de semillas"
+        },
+        {
+          "lang": "fa",
+          "value": "بذرتیماری"
+        },
+        {
+          "lang": "fr",
+          "value": "traitement des semences"
+        },
+        {
+          "lang": "hi",
+          "value": "बीज उपचार"
+        },
+        {
+          "lang": "hu",
+          "value": "magkezelés"
+        },
+        {
+          "lang": "it",
+          "value": "Trattamento dei semi"
+        },
+        {
+          "lang": "ja",
+          "value": "種子処理"
+        },
+        {
+          "lang": "ko",
+          "value": "종자처리"
+        },
+        {
+          "lang": "lo",
+          "value": "ການບຳບັດແກ່ນພັນ"
+        },
+        {
+          "lang": "pl",
+          "value": "Obróbka nasion"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_6989",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "es",
+          "value": "Servicio"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "serviço"
+        },
+        {
+          "lang": "sr",
+          "value": "услуге"
+        },
+        {
+          "lang": "sw",
+          "value": "huduma"
+        },
+        {
+          "lang": "nb",
+          "value": "tjenester"
+        },
+        {
+          "lang": "ro",
+          "value": "servicii"
+        },
+        {
+          "lang": "ka",
+          "value": "მომსახურება"
+        },
+        {
+          "lang": "uk",
+          "value": "послуги"
+        },
+        {
+          "lang": "ms",
+          "value": "Perkhidmatan"
+        },
+        {
+          "lang": "tr",
+          "value": "hizmet"
+        },
+        {
+          "lang": "zh",
+          "value": "服务"
+        },
+        {
+          "lang": "th",
+          "value": "บริการ"
+        },
+        {
+          "lang": "sk",
+          "value": "služby"
+        },
+        {
+          "lang": "ru",
+          "value": "услуги"
+        },
+        {
+          "lang": "ar",
+          "value": "خدمات"
+        },
+        {
+          "lang": "cs",
+          "value": "služby"
+        },
+        {
+          "lang": "de",
+          "value": "Dienst"
+        },
+        {
+          "lang": "en",
+          "value": "services"
+        },
+        {
+          "lang": "fa",
+          "value": "خدمات"
+        },
+        {
+          "lang": "fr",
+          "value": "service"
+        },
+        {
+          "lang": "hi",
+          "value": "सेवाएँ"
+        },
+        {
+          "lang": "hu",
+          "value": "szolgáltatás"
+        },
+        {
+          "lang": "it",
+          "value": "Servizi"
+        },
+        {
+          "lang": "ja",
+          "value": "サービス"
+        },
+        {
+          "lang": "ko",
+          "value": "용역"
+        },
+        {
+          "lang": "lo",
+          "value": "ບໍລິການ"
+        },
+        {
+          "lang": "pl",
+          "value": "Usługi"
+        },
+        {
+          "lang": "pt",
+          "value": "serviço"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_7401",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "sw",
+          "value": "kufisha vijidudu"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "esterilização reprodutiva"
+        },
+        {
+          "lang": "be",
+          "value": "стэрылізацыя"
+        },
+        {
+          "lang": "ka",
+          "value": "სტერილიზაცია"
+        },
+        {
+          "lang": "et",
+          "value": "steriliseerimine"
+        },
+        {
+          "lang": "uk",
+          "value": "стерилізація"
+        },
+        {
+          "lang": "tr",
+          "value": "kısırlaştırma"
+        },
+        {
+          "lang": "zh",
+          "value": "绝育"
+        },
+        {
+          "lang": "th",
+          "value": "การทำให้เป็นหมัน"
+        },
+        {
+          "lang": "sk",
+          "value": "sterilizácia"
+        },
+        {
+          "lang": "ru",
+          "value": "стерилизация"
+        },
+        {
+          "lang": "pt",
+          "value": "esterilização (reprodução)"
+        },
+        {
+          "lang": "ar",
+          "value": "تعقيم"
+        },
+        {
+          "lang": "cs",
+          "value": "sterilizace"
+        },
+        {
+          "lang": "de",
+          "value": "Sterilisation"
+        },
+        {
+          "lang": "en",
+          "value": "sterilization"
+        },
+        {
+          "lang": "es",
+          "value": "Esterilización (reproducción)"
+        },
+        {
+          "lang": "fa",
+          "value": "نازاسازی"
+        },
+        {
+          "lang": "fr",
+          "value": "stérilisation"
+        },
+        {
+          "lang": "hi",
+          "value": "निर्जर्मीकरण"
+        },
+        {
+          "lang": "hu",
+          "value": "sterilizáció"
+        },
+        {
+          "lang": "it",
+          "value": "Sterilizzazione sessuale"
+        },
+        {
+          "lang": "ja",
+          "value": "不妊化"
+        },
+        {
+          "lang": "ko",
+          "value": "단종"
+        },
+        {
+          "lang": "lo",
+          "value": "ການເຮັດໃຫ້ເປັນໝັນ"
+        },
+        {
+          "lang": "pl",
+          "value": "Sterylizacja"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_7402",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "pt-BR",
+          "value": "esterilização"
+        },
+        {
+          "lang": "sw",
+          "value": "kufunga kizazi"
+        },
+        {
+          "lang": "be",
+          "value": "абеззаражванне"
+        },
+        {
+          "lang": "nb",
+          "value": "sterilisering"
+        },
+        {
+          "lang": "uk",
+          "value": "знезараження"
+        },
+        {
+          "lang": "tr",
+          "value": "sterilizasyon"
+        },
+        {
+          "lang": "zh",
+          "value": "灭菌"
+        },
+        {
+          "lang": "th",
+          "value": "การทำให้ปราศจากเชื้อ"
+        },
+        {
+          "lang": "sk",
+          "value": "sterilizovanie"
+        },
+        {
+          "lang": "ru",
+          "value": "обеззараживание"
+        },
+        {
+          "lang": "pt",
+          "value": "esterilização microbiana"
+        },
+        {
+          "lang": "ar",
+          "value": "تعقيم"
+        },
+        {
+          "lang": "cs",
+          "value": "sterilování"
+        },
+        {
+          "lang": "de",
+          "value": "Sterilisieren"
+        },
+        {
+          "lang": "en",
+          "value": "sterilizing"
+        },
+        {
+          "lang": "es",
+          "value": "Esterilización"
+        },
+        {
+          "lang": "fa",
+          "value": "سترون‌کردن"
+        },
+        {
+          "lang": "fr",
+          "value": "stérilisation (germes)"
+        },
+        {
+          "lang": "hi",
+          "value": "निजर्मीकरण"
+        },
+        {
+          "lang": "hu",
+          "value": "sterilizálás"
+        },
+        {
+          "lang": "it",
+          "value": "Sterilizzazione"
+        },
+        {
+          "lang": "ja",
+          "value": "殺菌"
+        },
+        {
+          "lang": "ko",
+          "value": "살균"
+        },
+        {
+          "lang": "lo",
+          "value": "ການອະເຊື້ອ"
+        },
+        {
+          "lang": "pl",
+          "value": "Sterylizowanie (wyjaławianie)"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_7427",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "sw",
+          "value": "hifadhi"
+        },
+        {
+          "lang": "be",
+          "value": "захаванне"
+        },
+        {
+          "lang": "ka",
+          "value": "შენახვა"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "armazenamento"
+        },
+        {
+          "lang": "ro",
+          "value": "depozitare"
+        },
+        {
+          "lang": "uk",
+          "value": "зберігання"
+        },
+        {
+          "lang": "tr",
+          "value": "depolama"
+        },
+        {
+          "lang": "zh",
+          "value": "储藏"
+        },
+        {
+          "lang": "th",
+          "value": "การเก็บรักษา"
+        },
+        {
+          "lang": "sk",
+          "value": "skladovanie"
+        },
+        {
+          "lang": "ru",
+          "value": "хранение"
+        },
+        {
+          "lang": "pt",
+          "value": "armazenamento"
+        },
+        {
+          "lang": "ar",
+          "value": "تخزين"
+        },
+        {
+          "lang": "cs",
+          "value": "skladování"
+        },
+        {
+          "lang": "de",
+          "value": "Lagerung"
+        },
+        {
+          "lang": "en",
+          "value": "storage"
+        },
+        {
+          "lang": "es",
+          "value": "Almacenamiento"
+        },
+        {
+          "lang": "fa",
+          "value": "ذخیره‌سازی"
+        },
+        {
+          "lang": "fr",
+          "value": "stockage"
+        },
+        {
+          "lang": "hi",
+          "value": "भण्डारण"
+        },
+        {
+          "lang": "hu",
+          "value": "raktározás"
+        },
+        {
+          "lang": "it",
+          "value": "Immagazzinamento"
+        },
+        {
+          "lang": "ja",
+          "value": "貯蔵"
+        },
+        {
+          "lang": "ko",
+          "value": "저장"
+        },
+        {
+          "lang": "lo",
+          "value": "ການເກັບຮັກສາ"
+        },
+        {
+          "lang": "pl",
+          "value": "Przechowywanie"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_74f047e5",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "be",
+          "value": "адкліканне прадукцыі"
+        },
+        {
+          "lang": "sw",
+          "value": "kumbuka bidhaa"
+        },
+        {
+          "lang": "da",
+          "value": "tilbagekald af produkter"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "recall de produto"
+        },
+        {
+          "lang": "nb",
+          "value": "tilbakekalling av produkter"
+        },
+        {
+          "lang": "de",
+          "value": "Produktrückruf"
+        },
+        {
+          "lang": "tr",
+          "value": "ürün geri çağırma"
+        },
+        {
+          "lang": "zh",
+          "value": "产品召回"
+        },
+        {
+          "lang": "ru",
+          "value": "отзыв продукции"
+        },
+        {
+          "lang": "fr",
+          "value": "retrait du marché d'un produit"
+        },
+        {
+          "lang": "es",
+          "value": "Retirada de un producto del mercado"
+        },
+        {
+          "lang": "ar",
+          "value": "سحب المنتج من الأسواق"
+        },
+        {
+          "lang": "en",
+          "value": "product recall"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_7533",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "be",
+          "value": "хірургічныя аперацыі"
+        },
+        {
+          "lang": "es",
+          "value": "Operación quirúrgica"
+        },
+        {
+          "lang": "sw",
+          "value": "shughuli za upasuaji"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "cirurgia"
+        },
+        {
+          "lang": "ro",
+          "value": "operații chirurgicale"
+        },
+        {
+          "lang": "te",
+          "value": "జంతువుల శస్త్ర చికిత్సలు"
+        },
+        {
+          "lang": "tr",
+          "value": "cerrahi operasyon"
+        },
+        {
+          "lang": "zh",
+          "value": "外科手术"
+        },
+        {
+          "lang": "th",
+          "value": "การผ่าตัด"
+        },
+        {
+          "lang": "sk",
+          "value": "chirurgické operácie"
+        },
+        {
+          "lang": "ru",
+          "value": "хирургические операции"
+        },
+        {
+          "lang": "ar",
+          "value": "عمليات جراحية"
+        },
+        {
+          "lang": "cs",
+          "value": "chirurgické operace"
+        },
+        {
+          "lang": "de",
+          "value": "chirurgische Operation"
+        },
+        {
+          "lang": "en",
+          "value": "surgical operations"
+        },
+        {
+          "lang": "fa",
+          "value": "عمل‌های جراحی"
+        },
+        {
+          "lang": "fr",
+          "value": "opération chirurgicale"
+        },
+        {
+          "lang": "hi",
+          "value": "शल्यक्रिया चीर फाड़ वाले आपरेशन"
+        },
+        {
+          "lang": "hu",
+          "value": "sebészeti beavatkozás"
+        },
+        {
+          "lang": "it",
+          "value": "Operazioni chirurgiche"
+        },
+        {
+          "lang": "ja",
+          "value": "外科手術"
+        },
+        {
+          "lang": "ko",
+          "value": "외과적수술"
+        },
+        {
+          "lang": "lo",
+          "value": "ການຜ່າຕັດ"
+        },
+        {
+          "lang": "pl",
+          "value": "Operacja chirurgiczna"
+        },
+        {
+          "lang": "pt",
+          "value": "operação cirúrgica"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_7536",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "da",
+          "value": "opmåling"
+        },
+        {
+          "lang": "sw",
+          "value": "kutazama"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "reconhecimento"
+        },
+        {
+          "lang": "de",
+          "value": "Vermessung"
+        },
+        {
+          "lang": "tr",
+          "value": "etüt etme"
+        },
+        {
+          "lang": "zh",
+          "value": "勘测"
+        },
+        {
+          "lang": "th",
+          "value": "การสำรวจ"
+        },
+        {
+          "lang": "ru",
+          "value": "обследование (процесс)"
+        },
+        {
+          "lang": "pt",
+          "value": "reconhecimento"
+        },
+        {
+          "lang": "hi",
+          "value": "सर्वेक्षण"
+        },
+        {
+          "lang": "hu",
+          "value": "ellenőrzés"
+        },
+        {
+          "lang": "sk",
+          "value": "vymeriavanie"
+        },
+        {
+          "lang": "ar",
+          "value": "مسح"
+        },
+        {
+          "lang": "cs",
+          "value": "snímání"
+        },
+        {
+          "lang": "en",
+          "value": "surveying"
+        },
+        {
+          "lang": "es",
+          "value": "Procedimiento de la encuesta"
+        },
+        {
+          "lang": "fa",
+          "value": "نقشه‌برداری"
+        },
+        {
+          "lang": "fr",
+          "value": "relevé (des données)"
+        },
+        {
+          "lang": "it",
+          "value": "Rilevamento di dati"
+        },
+        {
+          "lang": "ja",
+          "value": "測量"
+        },
+        {
+          "lang": "ko",
+          "value": "조사방법"
+        },
+        {
+          "lang": "lo",
+          "value": "ການສຳຫຼວດ"
+        },
+        {
+          "lang": "pl",
+          "value": "Miernictwo"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_7645",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "sw",
+          "value": "uhamisho wa teknolojia"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "transferência de tecnologia"
+        },
+        {
+          "lang": "sr",
+          "value": "трансфер технологије"
+        },
+        {
+          "lang": "ro",
+          "value": "transfer de tehnologie"
+        },
+        {
+          "lang": "uk",
+          "value": "трансфер технологій"
+        },
+        {
+          "lang": "ka",
+          "value": "ტექნოლოგიის გადაცემა"
+        },
+        {
+          "lang": "te",
+          "value": "సాంకేతిక బదలాయింపు"
+        },
+        {
+          "lang": "tr",
+          "value": "teknoloji transferi"
+        },
+        {
+          "lang": "zh",
+          "value": "技术转让"
+        },
+        {
+          "lang": "th",
+          "value": "การถ่ายทอดเทคโนโลยี"
+        },
+        {
+          "lang": "sk",
+          "value": "prenos technológie"
+        },
+        {
+          "lang": "ru",
+          "value": "трансферт технологий"
+        },
+        {
+          "lang": "pt",
+          "value": "transferência de tecnologia"
+        },
+        {
+          "lang": "ar",
+          "value": "نقل التكنولوجيا"
+        },
+        {
+          "lang": "cs",
+          "value": "přenos technologie"
+        },
+        {
+          "lang": "de",
+          "value": "Technologietransfer"
+        },
+        {
+          "lang": "en",
+          "value": "technology transfer"
+        },
+        {
+          "lang": "es",
+          "value": "Transferencia de tecnología"
+        },
+        {
+          "lang": "fa",
+          "value": "انتقال فناوری"
+        },
+        {
+          "lang": "fr",
+          "value": "transfert de technologie"
+        },
+        {
+          "lang": "hi",
+          "value": "प्राविधिक/तकनीकी स्थानांतरण"
+        },
+        {
+          "lang": "hu",
+          "value": "technológia transzfer"
+        },
+        {
+          "lang": "it",
+          "value": "Trasferimento delle tecnologie"
+        },
+        {
+          "lang": "ja",
+          "value": "技術移転"
+        },
+        {
+          "lang": "ko",
+          "value": "기술이전"
+        },
+        {
+          "lang": "lo",
+          "value": "ການຖ່າຍທອດເຕັກໂນໂລຢີ"
+        },
+        {
+          "lang": "pl",
+          "value": "Transfer technologii"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_782dd4c3",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "th",
+          "value": "การนำไปปฏิบัติ"
+        },
+        {
+          "lang": "zh",
+          "value": "实施"
+        },
+        {
+          "lang": "en",
+          "value": "implementation"
+        },
+        {
+          "lang": "fr",
+          "value": "implémentation"
+        },
+        {
+          "lang": "es",
+          "value": "Implementación"
+        },
+        {
+          "lang": "de",
+          "value": "Implementation"
+        },
+        {
+          "lang": "ru",
+          "value": "осуществление"
+        },
+        {
+          "lang": "sv",
+          "value": "genomförande"
+        },
+        {
+          "lang": "tr",
+          "value": "uygulamaya koyma"
+        },
+        {
+          "lang": "it",
+          "value": "Implementazione"
+        },
+        {
+          "lang": "cs",
+          "value": "implementace"
+        },
+        {
+          "lang": "ro",
+          "value": "implementare"
+        },
+        {
+          "lang": "sw",
+          "value": "utekelezaji"
+        },
+        {
+          "lang": "ar",
+          "value": "تَنْفِيذ"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "implementação"
+        },
+        {
+          "lang": "be",
+          "value": "ажыццяўленне"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_7848",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "pt-BR",
+          "value": "Comércio"
+        },
+        {
+          "lang": "sw",
+          "value": "biashara"
+        },
+        {
+          "lang": "et",
+          "value": "kaubandus"
+        },
+        {
+          "lang": "uk",
+          "value": "торгівля"
+        },
+        {
+          "lang": "ro",
+          "value": "comerț"
+        },
+        {
+          "lang": "ka",
+          "value": "ვაჭრობა"
+        },
+        {
+          "lang": "te",
+          "value": "వాణిజ్యం"
+        },
+        {
+          "lang": "tr",
+          "value": "ticaret"
+        },
+        {
+          "lang": "zh",
+          "value": "贸易"
+        },
+        {
+          "lang": "th",
+          "value": "การค้า"
+        },
+        {
+          "lang": "sk",
+          "value": "obchod"
+        },
+        {
+          "lang": "ru",
+          "value": "торговля"
+        },
+        {
+          "lang": "pt",
+          "value": "Comércio"
+        },
+        {
+          "lang": "ar",
+          "value": "التجارة"
+        },
+        {
+          "lang": "cs",
+          "value": "obchod"
+        },
+        {
+          "lang": "de",
+          "value": "Handel"
+        },
+        {
+          "lang": "en",
+          "value": "trade"
+        },
+        {
+          "lang": "es",
+          "value": "Comercio"
+        },
+        {
+          "lang": "fa",
+          "value": "تجارت"
+        },
+        {
+          "lang": "fr",
+          "value": "commerce"
+        },
+        {
+          "lang": "hi",
+          "value": "व्यापार"
+        },
+        {
+          "lang": "hu",
+          "value": "kereskedelem"
+        },
+        {
+          "lang": "it",
+          "value": "Commercio"
+        },
+        {
+          "lang": "ja",
+          "value": "商業"
+        },
+        {
+          "lang": "ko",
+          "value": "무역"
+        },
+        {
+          "lang": "lo",
+          "value": "ການຄ້າ"
+        },
+        {
+          "lang": "pl",
+          "value": "Handel"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_7874",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "ca",
+          "value": "Transport"
+        },
+        {
+          "lang": "sw",
+          "value": "usafiri"
+        },
+        {
+          "lang": "nb",
+          "value": "transport"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "transporte"
+        },
+        {
+          "lang": "ro",
+          "value": "transport"
+        },
+        {
+          "lang": "ru",
+          "value": "перевозки"
+        },
+        {
+          "lang": "ka",
+          "value": "ტრანსპორტი"
+        },
+        {
+          "lang": "ms",
+          "value": "Pengangkutan"
+        },
+        {
+          "lang": "te",
+          "value": "రవాణా"
+        },
+        {
+          "lang": "tr",
+          "value": "taşımacılık"
+        },
+        {
+          "lang": "zh",
+          "value": "运输"
+        },
+        {
+          "lang": "th",
+          "value": "การคมนาคม"
+        },
+        {
+          "lang": "sk",
+          "value": "doprava"
+        },
+        {
+          "lang": "pt",
+          "value": "transporte"
+        },
+        {
+          "lang": "ar",
+          "value": "نقل"
+        },
+        {
+          "lang": "cs",
+          "value": "doprava"
+        },
+        {
+          "lang": "de",
+          "value": "Transport"
+        },
+        {
+          "lang": "en",
+          "value": "transport"
+        },
+        {
+          "lang": "es",
+          "value": "Transporte"
+        },
+        {
+          "lang": "fa",
+          "value": "حمل و نقل"
+        },
+        {
+          "lang": "fr",
+          "value": "transport"
+        },
+        {
+          "lang": "hi",
+          "value": "परिवहन"
+        },
+        {
+          "lang": "hu",
+          "value": "szállítás"
+        },
+        {
+          "lang": "it",
+          "value": "Trasporto"
+        },
+        {
+          "lang": "ja",
+          "value": "輸送"
+        },
+        {
+          "lang": "ko",
+          "value": "수송"
+        },
+        {
+          "lang": "lo",
+          "value": "ການຂົນສົ່ງ"
+        },
+        {
+          "lang": "pl",
+          "value": "Transport"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_7bae3d7d",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "ro",
+          "value": "reînnoire"
+        },
+        {
+          "lang": "en",
+          "value": "renewal"
+        },
+        {
+          "lang": "nb",
+          "value": "fornyelse"
+        },
+        {
+          "lang": "tr",
+          "value": "yenileme"
+        },
+        {
+          "lang": "de",
+          "value": "Erneuerung"
+        },
+        {
+          "lang": "it",
+          "value": "Rinnovo"
+        },
+        {
+          "lang": "fr",
+          "value": "renouvellement"
+        },
+        {
+          "lang": "cs",
+          "value": "renovace"
+        },
+        {
+          "lang": "es",
+          "value": "Renovación"
+        },
+        {
+          "lang": "zh",
+          "value": "更新"
+        },
+        {
+          "lang": "be",
+          "value": "аднаўленне"
+        },
+        {
+          "lang": "ar",
+          "value": "تَجْدِيد"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "renovação"
+        },
+        {
+          "lang": "sw",
+          "value": "fanya upya"
+        },
+        {
+          "lang": "ru",
+          "value": "обновление"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_7eb51b94",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "cs",
+          "value": "svařování"
+        },
+        {
+          "lang": "it",
+          "value": "Saldatura"
+        },
+        {
+          "lang": "sv",
+          "value": "svetsning"
+        },
+        {
+          "lang": "sw",
+          "value": "kuunga"
+        },
+        {
+          "lang": "ro",
+          "value": "sudare"
+        },
+        {
+          "lang": "uk",
+          "value": "зварювання"
+        },
+        {
+          "lang": "en",
+          "value": "welding"
+        },
+        {
+          "lang": "et",
+          "value": "keevitamine"
+        },
+        {
+          "lang": "nb",
+          "value": "sveising"
+        },
+        {
+          "lang": "nn",
+          "value": "sveising"
+        },
+        {
+          "lang": "es",
+          "value": "Soldadura"
+        },
+        {
+          "lang": "fr",
+          "value": "soudage"
+        },
+        {
+          "lang": "ca",
+          "value": "Soldadura"
+        },
+        {
+          "lang": "ar",
+          "value": "اللحام"
+        },
+        {
+          "lang": "zh",
+          "value": "焊接"
+        },
+        {
+          "lang": "ru",
+          "value": "cварка"
+        },
+        {
+          "lang": "de",
+          "value": "Schweißen"
+        },
+        {
+          "lang": "tr",
+          "value": "kaynak yapma"
+        },
+        {
+          "lang": "ka",
+          "value": "შედუღება"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "soldagem"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_8152",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "ru",
+          "value": "оценка стоимости"
+        },
+        {
+          "lang": "sr",
+          "value": "вредновање"
+        },
+        {
+          "lang": "sw",
+          "value": "kisio cha kima"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "estimativa"
+        },
+        {
+          "lang": "zh",
+          "value": "价值评估"
+        },
+        {
+          "lang": "tr",
+          "value": "değerleme"
+        },
+        {
+          "lang": "th",
+          "value": "การประเมินค่า"
+        },
+        {
+          "lang": "sk",
+          "value": "oceňovanie"
+        },
+        {
+          "lang": "pt",
+          "value": "estimativa"
+        },
+        {
+          "lang": "ja",
+          "value": "評価"
+        },
+        {
+          "lang": "ko",
+          "value": "평가"
+        },
+        {
+          "lang": "ar",
+          "value": "تقييم"
+        },
+        {
+          "lang": "cs",
+          "value": "oceňování"
+        },
+        {
+          "lang": "de",
+          "value": "Bewertung"
+        },
+        {
+          "lang": "en",
+          "value": "valuation"
+        },
+        {
+          "lang": "es",
+          "value": "Estimación"
+        },
+        {
+          "lang": "fa",
+          "value": "ارزش‌گذاری"
+        },
+        {
+          "lang": "fr",
+          "value": "valeur d'estimation"
+        },
+        {
+          "lang": "hi",
+          "value": "मूल्याकंन"
+        },
+        {
+          "lang": "hu",
+          "value": "értékelés"
+        },
+        {
+          "lang": "it",
+          "value": "Stima"
+        },
+        {
+          "lang": "lo",
+          "value": "ການປະເມີນມູນຄ່າ"
+        },
+        {
+          "lang": "pl",
+          "value": "Wycena"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_816e729b",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "th",
+          "value": "การดำน้ำ"
+        },
+        {
+          "lang": "sw",
+          "value": "kupiga mbizi"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "mergulho"
+        },
+        {
+          "lang": "ru",
+          "value": "подводное плавание"
+        },
+        {
+          "lang": "ar",
+          "value": "غوص"
+        },
+        {
+          "lang": "cs",
+          "value": "potápění"
+        },
+        {
+          "lang": "ka",
+          "value": "ყვინთვა"
+        },
+        {
+          "lang": "de",
+          "value": "Tauchen"
+        },
+        {
+          "lang": "tr",
+          "value": "dalış"
+        },
+        {
+          "lang": "fr",
+          "value": "plongée sous-marine"
+        },
+        {
+          "lang": "es",
+          "value": "Buceo"
+        },
+        {
+          "lang": "nb",
+          "value": "dykking"
+        },
+        {
+          "lang": "zh",
+          "value": "潜水"
+        },
+        {
+          "lang": "en",
+          "value": "diving"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_8339",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "ka",
+          "value": "ამინდის მოდიფიკაცია"
+        },
+        {
+          "lang": "sw",
+          "value": "udhibiti wa hali ya hewa"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "controle climático"
+        },
+        {
+          "lang": "zh",
+          "value": "天气控制"
+        },
+        {
+          "lang": "uk",
+          "value": "регулювання погоди"
+        },
+        {
+          "lang": "ro",
+          "value": "controlul vremii"
+        },
+        {
+          "lang": "tr",
+          "value": "hava kontrolü"
+        },
+        {
+          "lang": "th",
+          "value": "การควบคุมสภาพอากาศ"
+        },
+        {
+          "lang": "sk",
+          "value": "ovládanie počasia"
+        },
+        {
+          "lang": "ru",
+          "value": "управление погодой"
+        },
+        {
+          "lang": "pt",
+          "value": "controlo climático"
+        },
+        {
+          "lang": "ar",
+          "value": "تحكم بالطقس"
+        },
+        {
+          "lang": "cs",
+          "value": "ovlivňování počasí"
+        },
+        {
+          "lang": "de",
+          "value": "Wetterbeeinflussung"
+        },
+        {
+          "lang": "en",
+          "value": "weather control"
+        },
+        {
+          "lang": "es",
+          "value": "Control meteorológico"
+        },
+        {
+          "lang": "fa",
+          "value": "کنترل وضع هوا"
+        },
+        {
+          "lang": "fr",
+          "value": "maîtrise du temps"
+        },
+        {
+          "lang": "hi",
+          "value": "मौसम नियंत्रण"
+        },
+        {
+          "lang": "hu",
+          "value": "időjárás elleni védekezés"
+        },
+        {
+          "lang": "it",
+          "value": "Controllo meteorologico"
+        },
+        {
+          "lang": "ja",
+          "value": "気象制御"
+        },
+        {
+          "lang": "ko",
+          "value": "기상조절"
+        },
+        {
+          "lang": "lo",
+          "value": "ການຄວບຄຸມດິນຟ້າອາກາດ"
+        },
+        {
+          "lang": "pl",
+          "value": "Kontrola pogody"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_88ebf476",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "cs",
+          "value": "intervence"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "intervenção"
+        },
+        {
+          "lang": "sw",
+          "value": "hatua za uingiliaji"
+        },
+        {
+          "lang": "th",
+          "value": "การแทรกแซง"
+        },
+        {
+          "lang": "en",
+          "value": "interventions"
+        },
+        {
+          "lang": "pt",
+          "value": "intervenção"
+        },
+        {
+          "lang": "es",
+          "value": "Intervención"
+        },
+        {
+          "lang": "fr",
+          "value": "intervention"
+        },
+        {
+          "lang": "ru",
+          "value": "вмешательство"
+        },
+        {
+          "lang": "ar",
+          "value": "تدخلات"
+        },
+        {
+          "lang": "zh",
+          "value": "干预"
+        },
+        {
+          "lang": "nb",
+          "value": "intervensjoner"
+        },
+        {
+          "lang": "nn",
+          "value": "intervensjonar"
+        },
+        {
+          "lang": "da",
+          "value": "interventioner"
+        },
+        {
+          "lang": "sv",
+          "value": "interventioner"
+        },
+        {
+          "lang": "de",
+          "value": "Intervention"
+        },
+        {
+          "lang": "tr",
+          "value": "karışma"
+        },
+        {
+          "lang": "ro",
+          "value": "intervenții"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_9000086",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "th",
+          "value": "การปฏิรูปเชิงสถาบัน"
+        },
+        {
+          "lang": "zh",
+          "value": "机构改革"
+        },
+        {
+          "lang": "sw",
+          "value": "mageuzi ya kitaasisi"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "reforma institucional"
+        },
+        {
+          "lang": "ar",
+          "value": "إصلاح مؤسساتي"
+        },
+        {
+          "lang": "cs",
+          "value": "institucionální reforma"
+        },
+        {
+          "lang": "en",
+          "value": "institutional reform"
+        },
+        {
+          "lang": "es",
+          "value": "Reforma institucional"
+        },
+        {
+          "lang": "fr",
+          "value": "réforme institutionnelle"
+        },
+        {
+          "lang": "hi",
+          "value": "संस्थागत नवीनीकरण"
+        },
+        {
+          "lang": "it",
+          "value": "Riforma istituzionale"
+        },
+        {
+          "lang": "pt",
+          "value": "reforma institucional"
+        },
+        {
+          "lang": "sk",
+          "value": "inštitucionálna reforma"
+        },
+        {
+          "lang": "tr",
+          "value": "kurumsal reform"
+        },
+        {
+          "lang": "te",
+          "value": "సంస్థాగత సంస్కరణ"
+        },
+        {
+          "lang": "de",
+          "value": "institutionelle Reform"
+        },
+        {
+          "lang": "uk",
+          "value": "інституційна реформа"
+        },
+        {
+          "lang": "ru",
+          "value": "институциональные реформы"
+        },
+        {
+          "lang": "ro",
+          "value": "reformă instituţională"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_9e278097",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "be",
+          "value": "перамовы"
+        },
+        {
+          "lang": "th",
+          "value": "การเจรจาต่อรอง"
+        },
+        {
+          "lang": "zh",
+          "value": "談判"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "negociação"
+        },
+        {
+          "lang": "ar",
+          "value": "تفاوض"
+        },
+        {
+          "lang": "fr",
+          "value": "négociation"
+        },
+        {
+          "lang": "en",
+          "value": "negotiation"
+        },
+        {
+          "lang": "es",
+          "value": "Negociación"
+        },
+        {
+          "lang": "it",
+          "value": "Negoziazione"
+        },
+        {
+          "lang": "tr",
+          "value": "müzakere"
+        },
+        {
+          "lang": "uk",
+          "value": "перемовини"
+        },
+        {
+          "lang": "ru",
+          "value": "переговоры"
+        },
+        {
+          "lang": "cs",
+          "value": "vyjednávání"
+        },
+        {
+          "lang": "de",
+          "value": "Verhandlung"
+        },
+        {
+          "lang": "ka",
+          "value": "მოლაპარაკება"
+        },
+        {
+          "lang": "da",
+          "value": "forhandling"
+        },
+        {
+          "lang": "nb",
+          "value": "forhandling"
+        },
+        {
+          "lang": "ro",
+          "value": "negociere"
+        },
+        {
+          "lang": "sw",
+          "value": "majadiliano"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_a97eb278",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "th",
+          "value": "การตรวจจับ"
+        },
+        {
+          "lang": "be",
+          "value": "выяўленне"
+        },
+        {
+          "lang": "en",
+          "value": "detection"
+        },
+        {
+          "lang": "es",
+          "value": "Detección"
+        },
+        {
+          "lang": "fr",
+          "value": "détection"
+        },
+        {
+          "lang": "ru",
+          "value": "выявление"
+        },
+        {
+          "lang": "ar",
+          "value": "كشف"
+        },
+        {
+          "lang": "tr",
+          "value": "belirleme"
+        },
+        {
+          "lang": "de",
+          "value": "Erkennung"
+        },
+        {
+          "lang": "ro",
+          "value": "detectare"
+        },
+        {
+          "lang": "nb",
+          "value": "deteksjon"
+        },
+        {
+          "lang": "cs",
+          "value": "detekce"
+        },
+        {
+          "lang": "it",
+          "value": "Detezione"
+        },
+        {
+          "lang": "zh",
+          "value": "探测"
+        },
+        {
+          "lang": "sw",
+          "value": "ugunduzi"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "detecção"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_aafbf0c8",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "ro",
+          "value": "recuperare"
+        },
+        {
+          "lang": "ru",
+          "value": "рекуперация"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "recuperação"
+        },
+        {
+          "lang": "ar",
+          "value": "استرداد"
+        },
+        {
+          "lang": "sw",
+          "value": "recuperation"
+        },
+        {
+          "lang": "es",
+          "value": "Recuperación"
+        },
+        {
+          "lang": "cs",
+          "value": "rekuperace"
+        },
+        {
+          "lang": "en",
+          "value": "recuperation"
+        },
+        {
+          "lang": "fr",
+          "value": "récupération"
+        },
+        {
+          "lang": "zh",
+          "value": "恢复"
+        },
+        {
+          "lang": "tr",
+          "value": "geri kazanım"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_b9d1a9fd",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "th",
+          "value": "การดำเนินการด้านสภาพภูมิอากาศ"
+        },
+        {
+          "lang": "en",
+          "value": "climate action"
+        },
+        {
+          "lang": "fr",
+          "value": "action climatique"
+        },
+        {
+          "lang": "zh",
+          "value": "气候行动"
+        },
+        {
+          "lang": "es",
+          "value": "Acción por el clima"
+        },
+        {
+          "lang": "ru",
+          "value": "действия по борьбе с изменением климата"
+        },
+        {
+          "lang": "ar",
+          "value": "الإجراءات المتعلقة بالمناخ"
+        },
+        {
+          "lang": "pt",
+          "value": "ação climática"
+        },
+        {
+          "lang": "nl",
+          "value": "klimaatactie"
+        },
+        {
+          "lang": "tr",
+          "value": "iklim eylemi"
+        },
+        {
+          "lang": "da",
+          "value": "klimahandling"
+        },
+        {
+          "lang": "nb",
+          "value": "klimahandling"
+        },
+        {
+          "lang": "nn",
+          "value": "klimahandling"
+        },
+        {
+          "lang": "sw",
+          "value": "hatua za kukabiliana na mabadiliko ya tabianchi"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "ação climática"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_bc882050",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "th",
+          "value": "การชดคืนต้นทุน"
+        },
+        {
+          "lang": "zh",
+          "value": "成本收回"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "custo de recuperação"
+        },
+        {
+          "lang": "de",
+          "value": "Kostendeckung"
+        },
+        {
+          "lang": "sw",
+          "value": "gharama ya kujipatia"
+        },
+        {
+          "lang": "tr",
+          "value": "maliyet kurtarma"
+        },
+        {
+          "lang": "ru",
+          "value": "возмещение затрат"
+        },
+        {
+          "lang": "fr",
+          "value": "recouvrement des coûts"
+        },
+        {
+          "lang": "es",
+          "value": "Recuperación de costos"
+        },
+        {
+          "lang": "ar",
+          "value": "استرداد التكاليف"
+        },
+        {
+          "lang": "en",
+          "value": "cost recovery"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_bea12d1e",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "sw",
+          "value": "ufuatiliaji na tathmini"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "monitoramento e avaliação"
+        },
+        {
+          "lang": "en",
+          "value": "monitoring and evaluation"
+        },
+        {
+          "lang": "ar",
+          "value": "رصد وتقييم"
+        },
+        {
+          "lang": "es",
+          "value": "Seguimiento y evaluación"
+        },
+        {
+          "lang": "fr",
+          "value": "suivi et évaluation"
+        },
+        {
+          "lang": "it",
+          "value": "Monitoraggio e valutazione"
+        },
+        {
+          "lang": "ru",
+          "value": "мониторинг и оценка"
+        },
+        {
+          "lang": "zh",
+          "value": "监测和评价"
+        },
+        {
+          "lang": "tr",
+          "value": "izleme değerlendirme"
+        },
+        {
+          "lang": "cs",
+          "value": "monitorování a vyhodnocování"
+        },
+        {
+          "lang": "de",
+          "value": "Monitoring und Evaluierung"
+        },
+        {
+          "lang": "ro",
+          "value": "monitoring și evaluare"
+        },
+        {
+          "lang": "ka",
+          "value": "მონიტორინგი და შეფასება"
+        },
+        {
+          "lang": "uk",
+          "value": "моніторинг і оцінювання"
+        },
+        {
+          "lang": "be",
+          "value": "маніторынг і ацэнка"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_c3c7073b",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "th",
+          "value": "การจอดเทียบท่า"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "atracação"
+        },
+        {
+          "lang": "ru",
+          "value": "постановка на якорь"
+        },
+        {
+          "lang": "sw",
+          "value": "kufunga gati"
+        },
+        {
+          "lang": "cs",
+          "value": "kotvení"
+        },
+        {
+          "lang": "de",
+          "value": "Anlegen (Schifffahrt)"
+        },
+        {
+          "lang": "tr",
+          "value": "iskeleye yanaşma"
+        },
+        {
+          "lang": "zh",
+          "value": "锚泊"
+        },
+        {
+          "lang": "fr",
+          "value": "accostage"
+        },
+        {
+          "lang": "es",
+          "value": "Atraque al muelle"
+        },
+        {
+          "lang": "ar",
+          "value": "الاقتراب من الرصيف أو المُساحلة"
+        },
+        {
+          "lang": "en",
+          "value": "berthing"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_c4d65583",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "be",
+          "value": "сачэнне"
+        },
+        {
+          "lang": "es",
+          "value": "Rastreo"
+        },
+        {
+          "lang": "en",
+          "value": "tracking"
+        },
+        {
+          "lang": "et",
+          "value": "jälgimine"
+        },
+        {
+          "lang": "fr",
+          "value": "traçage"
+        },
+        {
+          "lang": "ar",
+          "value": "تتبُّع"
+        },
+        {
+          "lang": "zh",
+          "value": "跟踪"
+        },
+        {
+          "lang": "tr",
+          "value": "takip"
+        },
+        {
+          "lang": "de",
+          "value": "Tracking"
+        },
+        {
+          "lang": "nb",
+          "value": "sporing"
+        },
+        {
+          "lang": "cs",
+          "value": "sledování"
+        },
+        {
+          "lang": "sw",
+          "value": "kufuatilia"
+        },
+        {
+          "lang": "ko",
+          "value": "추적"
+        },
+        {
+          "lang": "ru",
+          "value": "слежение"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "rastreamento"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_c9d7e397",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "be",
+          "value": "ратыфікацыя"
+        },
+        {
+          "lang": "sw",
+          "value": "idhini"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "ratificação"
+        },
+        {
+          "lang": "en",
+          "value": "ratification"
+        },
+        {
+          "lang": "ar",
+          "value": "تصديق"
+        },
+        {
+          "lang": "es",
+          "value": "Ratificación"
+        },
+        {
+          "lang": "fr",
+          "value": "ratification"
+        },
+        {
+          "lang": "it",
+          "value": "Ratifica"
+        },
+        {
+          "lang": "ru",
+          "value": "ратификация"
+        },
+        {
+          "lang": "zh",
+          "value": "批准"
+        },
+        {
+          "lang": "de",
+          "value": "Ratifizierung"
+        },
+        {
+          "lang": "da",
+          "value": "ratificering"
+        },
+        {
+          "lang": "sv",
+          "value": "ratificering"
+        },
+        {
+          "lang": "tr",
+          "value": "icazet"
+        },
+        {
+          "lang": "ka",
+          "value": "რატიფიკაცია"
+        },
+        {
+          "lang": "cs",
+          "value": "ratifikace"
+        },
+        {
+          "lang": "ro",
+          "value": "ratificare"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_d2e42ffb",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "sw",
+          "value": "niru"
+        },
+        {
+          "lang": "ru",
+          "value": "процесс затирки швов"
+        },
+        {
+          "lang": "uk",
+          "value": "затирання"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "rejuntar"
+        },
+        {
+          "lang": "ar",
+          "value": "الحشو"
+        },
+        {
+          "lang": "zh",
+          "value": "灌浆"
+        },
+        {
+          "lang": "cs",
+          "value": "vyspárování"
+        },
+        {
+          "lang": "es",
+          "value": "Lechada"
+        },
+        {
+          "lang": "fr",
+          "value": "jointoiement"
+        },
+        {
+          "lang": "de",
+          "value": "Verfugen"
+        },
+        {
+          "lang": "tr",
+          "value": "derz dolgu"
+        },
+        {
+          "lang": "nb",
+          "value": "fuging"
+        },
+        {
+          "lang": "en",
+          "value": "grouting"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_deb98e72",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "cs",
+          "value": "směna zárodečné plazmy"
+        },
+        {
+          "lang": "ro",
+          "value": "schimb de germoplasmă"
+        },
+        {
+          "lang": "en",
+          "value": "germplasm exchange"
+        },
+        {
+          "lang": "es",
+          "value": "Intercambio de germoplasma"
+        },
+        {
+          "lang": "fr",
+          "value": "échange de matériel génétique"
+        },
+        {
+          "lang": "ru",
+          "value": "обмен зародышевой плазмой"
+        },
+        {
+          "lang": "ar",
+          "value": "بادل البلازما الجرثومية"
+        },
+        {
+          "lang": "zh",
+          "value": "种质交换"
+        },
+        {
+          "lang": "nb",
+          "value": "utveksling av genetisk materiale"
+        },
+        {
+          "lang": "nl",
+          "value": "germplasm uitwisseling"
+        },
+        {
+          "lang": "pt",
+          "value": "troca de germoplasma"
+        },
+        {
+          "lang": "tr",
+          "value": "germplazm değişimi"
+        },
+        {
+          "lang": "uk",
+          "value": "обмін зародкової плазми"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "troca de germoplasma"
+        },
+        {
+          "lang": "it",
+          "value": "Scambio di germoplasma"
+        },
+        {
+          "lang": "sw",
+          "value": "kubadilishana wa germplasm"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_e6e33ae1",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "cs",
+          "value": "zacílování"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "alvejamento"
+        },
+        {
+          "lang": "sw",
+          "value": "kulenga"
+        },
+        {
+          "lang": "de",
+          "value": "Targeting"
+        },
+        {
+          "lang": "tr",
+          "value": "hedefleme"
+        },
+        {
+          "lang": "ru",
+          "value": "определение сферы охвата (программ)"
+        },
+        {
+          "lang": "zh",
+          "value": "目标瞄准"
+        },
+        {
+          "lang": "ar",
+          "value": "استهداف"
+        },
+        {
+          "lang": "es",
+          "value": "Focalización"
+        },
+        {
+          "lang": "fr",
+          "value": "ciblage"
+        },
+        {
+          "lang": "en",
+          "value": "targeting"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/c_f3efcce8",
+      "type": "skos:Concept",
+      "broader": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "th",
+          "value": "การดำเนินการเชิงป้องกันล่วงหน้า"
+        },
+        {
+          "lang": "en",
+          "value": "anticipatory action"
+        },
+        {
+          "lang": "ar",
+          "value": "إجراء استباقي"
+        },
+        {
+          "lang": "es",
+          "value": "Acción anticipatoria"
+        },
+        {
+          "lang": "fr",
+          "value": "action anticipatoire"
+        },
+        {
+          "lang": "ru",
+          "value": "упреждающее реагирование"
+        },
+        {
+          "lang": "zh",
+          "value": "前瞻型行动"
+        },
+        {
+          "lang": "pt",
+          "value": "acção antecipatória"
+        },
+        {
+          "lang": "tr",
+          "value": "katılımcı hareket"
+        },
+        {
+          "lang": "ro",
+          "value": "acțiune anticipativă"
+        },
+        {
+          "lang": "nb",
+          "value": "varslingsbasert innsats"
+        },
+        {
+          "lang": "nn",
+          "value": "varslingsbasert innsats"
+        },
+        {
+          "lang": "sw",
+          "value": "hatua za kujiandaa mapema"
+        },
+        {
+          "lang": "de",
+          "value": "vorausschauende humanitäre Hilfe"
+        },
+        {
+          "lang": "pt-BR",
+          "value": "ação antecipatória"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/skosCollection_47b33e75",
+      "type": "skos:Collection",
+      "skos:member": {
+        "uri": "http://aims.fao.org/aos/agrovoc/c_330834"
+      },
+      "prefLabel": [
+        {
+          "lang": "ar",
+          "value": "مجموعة حوكمة الأراضي"
+        },
+        {
+          "lang": "zh",
+          "value": "土地治理组"
+        },
+        {
+          "lang": "ru",
+          "value": "Управление земельными ресурсами (список терминов)"
+        },
+        {
+          "lang": "es",
+          "value": "Grupo sobre Gobernanza de la Tierra"
+        },
+        {
+          "lang": "fr",
+          "value": "Groupe sur Gouvernance Foncière"
+        },
+        {
+          "lang": "en",
+          "value": "Land Governance Group"
+        }
+      ]
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/xDef_47a14ae7",
+      "http://art.uniroma2.it/ontologies/vocbench#hasSource": "Cadastre and Land Administration Thesaurus (CaLAThe). Activity http://www.cadastralvocabulary.org/Concept.php?TID=200",
+      "dct:created": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2024-02-29T14:43:46"
+      },
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value": {
+        "lang": "en",
+        "value": "A sequence of actions organized towards a specific goal."
+      }
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/xDef_d8a81e42",
+      "dct:created": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2024-03-27T09:56:47"
+      },
+      "dct:source": {
+        "uri": "http://terim.tuba.gov.tr/"
+      },
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#value": {
+        "lang": "tr",
+        "value": "Bir projede zaman ve özkaynak tüketen, başı ve sonu tanımlı, belirli bir süre alan iş bütünü."
+      }
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/xl_ar_c979e918",
+      "type": "http://www.w3.org/2008/05/skos-xl#Label",
+      "dct:created": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2020-04-27T18:55:42Z"
+      },
+      "http://rdfs.org/ns/void#inDataset": {
+        "uri": "http://aims.fao.org/aos/agrovoc/void.ttl#Agrovoc"
+      },
+      "skos:notation": {
+        "type": "http://aims.fao.org/aos/agrovoc/AgrovocCode",
+        "value": "330834"
+      },
+      "http://www.w3.org/2008/05/skos-xl#literalForm": {
+        "lang": "ar",
+        "value": "انشطة"
+      }
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/xl_cs_1318924441012",
+      "type": "http://www.w3.org/2008/05/skos-xl#Label",
+      "dct:created": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2011-10-18T15:54:01Z"
+      },
+      "dct:modified": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2013-08-28T23:00:20Z"
+      },
+      "http://rdfs.org/ns/void#inDataset": {
+        "uri": "http://aims.fao.org/aos/agrovoc/void.ttl#Agrovoc"
+      },
+      "skos:notation": {
+        "type": "http://aims.fao.org/aos/agrovoc/AgrovocCode",
+        "value": "1318924441012"
+      },
+      "http://www.w3.org/2008/05/skos-xl#literalForm": {
+        "lang": "cs",
+        "value": "aktivity"
+      }
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/xl_da_5aa40889",
+      "type": "http://www.w3.org/2008/05/skos-xl#Label",
+      "dct:created": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2021-11-15T09:08:31"
+      },
+      "http://rdfs.org/ns/void#inDataset": {
+        "uri": "http://aims.fao.org/aos/agrovoc/void.ttl#Agrovoc"
+      },
+      "skos:notation": {
+        "type": "http://aims.fao.org/aos/agrovoc/AgrovocCode",
+        "value": "330834"
+      },
+      "http://www.w3.org/2008/05/skos-xl#literalForm": {
+        "lang": "da",
+        "value": "aktiviteter"
+      }
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/xl_de_1330936550823",
+      "type": "http://www.w3.org/2008/05/skos-xl#Label",
+      "http://aims.fao.org/aos/agrontology#hasSynonym": {
+        "uri": "http://aims.fao.org/aos/agrovoc/xl_de_1343897781451"
+      },
+      "http://aims.fao.org/aos/agrontology#isAcronymOf": {
+        "uri": "http://aims.fao.org/aos/agrovoc/xl_de_1343897781451"
+      },
+      "dct:created": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2012-03-05T16:35:50Z"
+      },
+      "dct:modified": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2012-08-21T22:58:00Z"
+      },
+      "http://rdfs.org/ns/void#inDataset": {
+        "uri": "http://aims.fao.org/aos/agrovoc/void.ttl#Agrovoc"
+      },
+      "skos:notation": {
+        "type": "http://aims.fao.org/aos/agrovoc/AgrovocCode",
+        "value": "330834"
+      },
+      "http://www.w3.org/2008/05/skos-xl#literalForm": {
+        "lang": "de",
+        "value": "Aktivität"
+      }
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/xl_de_1343897781451",
+      "type": "http://www.w3.org/2008/05/skos-xl#Label",
+      "http://aims.fao.org/aos/agrontology#hasSynonym": {
+        "uri": "http://aims.fao.org/aos/agrovoc/xl_de_1330936550823"
+      },
+      "http://aims.fao.org/aos/agrontology#isAcronymOf": {
+        "uri": "http://aims.fao.org/aos/agrovoc/xl_de_1330936550823"
+      },
+      "dct:created": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2012-08-02T16:56:21Z"
+      },
+      "dct:modified": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2012-08-02T21:13:45Z"
+      },
+      "http://rdfs.org/ns/void#inDataset": {
+        "uri": "http://aims.fao.org/aos/agrovoc/void.ttl#Agrovoc"
+      },
+      "skos:notation": {
+        "type": "http://aims.fao.org/aos/agrovoc/AgrovocCode",
+        "value": "1343897781451"
+      },
+      "http://www.w3.org/2008/05/skos-xl#literalForm": {
+        "lang": "de",
+        "value": "Tätigkeit"
+      }
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/xl_en_1299517186066",
+      "type": "http://www.w3.org/2008/05/skos-xl#Label",
+      "dct:created": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2008-09-25T00:00:00Z"
+      },
+      "http://rdfs.org/ns/void#inDataset": {
+        "uri": "http://aims.fao.org/aos/agrovoc/void.ttl#Agrovoc"
+      },
+      "skos:notation": {
+        "type": "http://aims.fao.org/aos/agrovoc/AgrovocCode",
+        "value": "330834"
+      },
+      "http://www.w3.org/2008/05/skos-xl#literalForm": {
+        "lang": "en",
+        "value": "activities"
+      }
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/xl_es_1299517186084",
+      "type": "http://www.w3.org/2008/05/skos-xl#Label",
+      "dct:created": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2010-05-12T00:00:00Z"
+      },
+      "dct:isReplacedBy": {
+        "uri": "http://aims.fao.org/aos/agrovoc/xl_es_e9941e63"
+      },
+      "dct:modified": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2024-07-03T16:11:42Z"
+      },
+      "http://rdfs.org/ns/void#inDataset": {
+        "uri": "http://aims.fao.org/aos/agrovoc/void.ttl#Agrovoc"
+      },
+      "skos:notation": {
+        "type": "http://aims.fao.org/aos/agrovoc/AgrovocCode",
+        "value": "330834"
+      },
+      "http://www.w3.org/2008/05/skos-xl#literalForm": {
+        "lang": "es",
+        "value": "Actividades"
+      }
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/xl_es_e9941e63",
+      "type": "http://www.w3.org/2008/05/skos-xl#Label",
+      "dct:created": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2024-07-03T16:11:42Z"
+      },
+      "http://rdfs.org/ns/void#inDataset": {
+        "uri": "http://aims.fao.org/aos/agrovoc/void.ttl#Agrovoc"
+      },
+      "skos:notation": {
+        "type": "http://aims.fao.org/aos/agrovoc/AgrovocCode",
+        "value": "330834"
+      },
+      "http://www.w3.org/2008/05/skos-xl#literalForm": {
+        "lang": "es",
+        "value": "Actividad"
+      }
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/xl_fr_1299517186101",
+      "type": "http://www.w3.org/2008/05/skos-xl#Label",
+      "dct:created": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2010-05-12T00:00:00Z"
+      },
+      "http://rdfs.org/ns/void#inDataset": {
+        "uri": "http://aims.fao.org/aos/agrovoc/void.ttl#Agrovoc"
+      },
+      "skos:notation": {
+        "type": "http://aims.fao.org/aos/agrovoc/AgrovocCode",
+        "value": "330834"
+      },
+      "http://www.w3.org/2008/05/skos-xl#literalForm": {
+        "lang": "fr",
+        "value": "activité"
+      }
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/xl_hi_348fcc8f",
+      "type": "http://www.w3.org/2008/05/skos-xl#Label",
+      "dct:created": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2020-07-01T08:31:19.755+02:00"
+      },
+      "http://rdfs.org/ns/void#inDataset": {
+        "uri": "http://aims.fao.org/aos/agrovoc/void.ttl#Agrovoc"
+      },
+      "skos:notation": {
+        "type": "http://aims.fao.org/aos/agrovoc/AgrovocCode",
+        "value": "330834"
+      },
+      "http://www.w3.org/2008/05/skos-xl#literalForm": {
+        "lang": "hi",
+        "value": "कार्यकलाप"
+      }
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/xl_it_1330936584382",
+      "type": "http://www.w3.org/2008/05/skos-xl#Label",
+      "dct:created": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2012-03-05T16:36:24Z"
+      },
+      "dct:modified": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2013-08-22T20:37:47Z"
+      },
+      "http://rdfs.org/ns/void#inDataset": {
+        "uri": "http://aims.fao.org/aos/agrovoc/void.ttl#Agrovoc"
+      },
+      "skos:notation": {
+        "type": "http://aims.fao.org/aos/agrovoc/AgrovocCode",
+        "value": "330834"
+      },
+      "http://www.w3.org/2008/05/skos-xl#literalForm": {
+        "lang": "it",
+        "value": "Attività"
+      }
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/xl_ka_f8a4263f",
+      "type": "http://www.w3.org/2008/05/skos-xl#Label",
+      "dct:created": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2018-09-26T13:46:10.873+02:00"
+      },
+      "http://rdfs.org/ns/void#inDataset": {
+        "uri": "http://aims.fao.org/aos/agrovoc/void.ttl#Agrovoc"
+      },
+      "skos:notation": {
+        "type": "http://aims.fao.org/aos/agrovoc/AgrovocCode",
+        "value": "330834"
+      },
+      "http://www.w3.org/2008/05/skos-xl#literalForm": {
+        "lang": "ka",
+        "value": "საქმიანობა"
+      }
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/xl_ms_1313985585804",
+      "type": "http://www.w3.org/2008/05/skos-xl#Label",
+      "dct:created": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2011-08-22T11:59:45Z"
+      },
+      "dct:modified": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2013-08-21T17:24:32Z"
+      },
+      "http://rdfs.org/ns/void#inDataset": {
+        "uri": "http://aims.fao.org/aos/agrovoc/void.ttl#Agrovoc"
+      },
+      "skos:notation": {
+        "type": "http://aims.fao.org/aos/agrovoc/AgrovocCode",
+        "value": "1313985585804"
+      },
+      "http://www.w3.org/2008/05/skos-xl#literalForm": {
+        "lang": "ms",
+        "value": "Aktiviti"
+      }
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/xl_nb_cc1ed7c8",
+      "type": "http://www.w3.org/2008/05/skos-xl#Label",
+      "dct:created": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2019-04-30T14:04:29.557+02:00"
+      },
+      "http://rdfs.org/ns/void#inDataset": {
+        "uri": "http://aims.fao.org/aos/agrovoc/void.ttl#Agrovoc"
+      },
+      "skos:notation": {
+        "type": "http://aims.fao.org/aos/agrovoc/AgrovocCode",
+        "value": "330834"
+      },
+      "http://www.w3.org/2008/05/skos-xl#literalForm": {
+        "lang": "nb",
+        "value": "aktiviteter"
+      }
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/xl_nn_c5f6c38b",
+      "type": "http://www.w3.org/2008/05/skos-xl#Label",
+      "dct:created": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2023-10-09T14:34:23"
+      },
+      "http://rdfs.org/ns/void#inDataset": {
+        "uri": "http://aims.fao.org/aos/agrovoc/void.ttl#Agrovoc"
+      },
+      "skos:notation": {
+        "type": "http://aims.fao.org/aos/agrovoc/AgrovocCode",
+        "value": "330834"
+      },
+      "http://www.w3.org/2008/05/skos-xl#literalForm": {
+        "lang": "nn",
+        "value": "aktivitetar"
+      }
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/xl_pt-BR_ec1c6b34",
+      "type": "http://www.w3.org/2008/05/skos-xl#Label",
+      "dct:created": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2024-01-29T15:17:00"
+      },
+      "http://rdfs.org/ns/void#inDataset": {
+        "uri": "http://aims.fao.org/aos/agrovoc/void.ttl#Agrovoc"
+      },
+      "skos:notation": {
+        "type": "http://aims.fao.org/aos/agrovoc/AgrovocCode",
+        "value": "330834"
+      },
+      "http://www.w3.org/2008/05/skos-xl#literalForm": {
+        "lang": "pt-BR",
+        "value": "atividades"
+      }
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/xl_pt_eb06086f",
+      "type": "http://www.w3.org/2008/05/skos-xl#Label",
+      "dct:created": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2019-12-04T10:23:30.019+01:00"
+      },
+      "dct:modified": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2021-06-25T16:29:34"
+      },
+      "http://rdfs.org/ns/void#inDataset": {
+        "uri": "http://aims.fao.org/aos/agrovoc/void.ttl#Agrovoc"
+      },
+      "skos:notation": {
+        "type": "http://aims.fao.org/aos/agrovoc/AgrovocCode",
+        "value": "330834"
+      },
+      "http://www.w3.org/2008/05/skos-xl#literalForm": {
+        "lang": "pt",
+        "value": "atividades"
+      }
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/xl_ro_616d11c2",
+      "type": "http://www.w3.org/2008/05/skos-xl#Label",
+      "dct:created": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2016-09-22T11:10:41Z"
+      },
+      "dct:modified": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2017-03-15T12:48:55Z"
+      },
+      "http://rdfs.org/ns/void#inDataset": {
+        "uri": "http://aims.fao.org/aos/agrovoc/void.ttl#Agrovoc"
+      },
+      "skos:notation": {
+        "type": "http://aims.fao.org/aos/agrovoc/AgrovocCode",
+        "value": "330834"
+      },
+      "http://www.w3.org/2008/05/skos-xl#literalForm": {
+        "lang": "ro",
+        "value": "activităţi"
+      }
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/xl_ru_e4b731e7",
+      "type": "http://www.w3.org/2008/05/skos-xl#Label",
+      "dct:created": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2018-09-12T14:04:14.797+02:00"
+      },
+      "http://rdfs.org/ns/void#inDataset": {
+        "uri": "http://aims.fao.org/aos/agrovoc/void.ttl#Agrovoc"
+      },
+      "skos:notation": {
+        "type": "http://aims.fao.org/aos/agrovoc/AgrovocCode",
+        "value": "330834"
+      },
+      "http://www.w3.org/2008/05/skos-xl#literalForm": {
+        "lang": "ru",
+        "value": "деятельность"
+      }
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/xl_sk_cd40f8e0",
+      "type": "http://www.w3.org/2008/05/skos-xl#Label",
+      "dct:created": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2021-02-05T13:12:40"
+      },
+      "http://rdfs.org/ns/void#inDataset": {
+        "uri": "http://aims.fao.org/aos/agrovoc/void.ttl#Agrovoc"
+      },
+      "skos:notation": {
+        "type": "http://aims.fao.org/aos/agrovoc/AgrovocCode",
+        "value": "330834"
+      },
+      "http://www.w3.org/2008/05/skos-xl#literalForm": {
+        "lang": "sk",
+        "value": "aktivity"
+      }
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/xl_sr_ddbf4a14",
+      "type": "http://www.w3.org/2008/05/skos-xl#Label",
+      "dct:created": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2020-01-17T09:19:13.587+01:00"
+      },
+      "http://rdfs.org/ns/void#inDataset": {
+        "uri": "http://aims.fao.org/aos/agrovoc/void.ttl#Agrovoc"
+      },
+      "skos:notation": {
+        "type": "http://aims.fao.org/aos/agrovoc/AgrovocCode",
+        "value": "330834"
+      },
+      "http://www.w3.org/2008/05/skos-xl#literalForm": {
+        "lang": "sr",
+        "value": "активност"
+      }
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/xl_sv_65101db3",
+      "type": "http://www.w3.org/2008/05/skos-xl#Label",
+      "dct:created": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2024-09-13T14:08:17"
+      },
+      "http://rdfs.org/ns/void#inDataset": {
+        "uri": "http://aims.fao.org/aos/agrovoc/void.ttl#Agrovoc"
+      },
+      "skos:notation": {
+        "type": "http://aims.fao.org/aos/agrovoc/AgrovocCode",
+        "value": "330834"
+      },
+      "http://www.w3.org/2008/05/skos-xl#literalForm": {
+        "lang": "sv",
+        "value": "aktiviteter"
+      }
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/xl_sw_de9acdf6",
+      "type": "http://www.w3.org/2008/05/skos-xl#Label",
+      "dct:created": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2019-12-04T10:24:01.499+01:00"
+      },
+      "http://rdfs.org/ns/void#inDataset": {
+        "uri": "http://aims.fao.org/aos/agrovoc/void.ttl#Agrovoc"
+      },
+      "skos:notation": {
+        "type": "http://aims.fao.org/aos/agrovoc/AgrovocCode",
+        "value": "330834"
+      },
+      "http://www.w3.org/2008/05/skos-xl#literalForm": {
+        "lang": "sw",
+        "value": "shughuli"
+      }
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/xl_th_005d60d5",
+      "type": "http://www.w3.org/2008/05/skos-xl#Label",
+      "dct:created": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2025-07-22T11:15:34"
+      },
+      "http://rdfs.org/ns/void#inDataset": {
+        "uri": "http://aims.fao.org/aos/agrovoc/void.ttl#Agrovoc"
+      },
+      "skos:notation": {
+        "type": "http://aims.fao.org/aos/agrovoc/AgrovocCode",
+        "value": "330834"
+      },
+      "http://www.w3.org/2008/05/skos-xl#literalForm": {
+        "lang": "th",
+        "value": "กิจกรรม"
+      }
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/xl_tr_1331561573252",
+      "type": "http://www.w3.org/2008/05/skos-xl#Label",
+      "dct:created": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2012-03-12T22:12:53Z"
+      },
+      "dct:modified": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2017-09-22T14:09:05Z"
+      },
+      "http://rdfs.org/ns/void#inDataset": {
+        "uri": "http://aims.fao.org/aos/agrovoc/void.ttl#Agrovoc"
+      },
+      "skos:notation": {
+        "type": "http://aims.fao.org/aos/agrovoc/AgrovocCode",
+        "value": "330834"
+      },
+      "http://www.w3.org/2008/05/skos-xl#literalForm": {
+        "lang": "tr",
+        "value": "etkinlik"
+      }
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/xl_tr_1331561600472",
+      "type": "http://www.w3.org/2008/05/skos-xl#Label",
+      "dct:created": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2012-03-12T22:13:20Z"
+      },
+      "dct:modified": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2017-09-22T14:09:07Z"
+      },
+      "http://rdfs.org/ns/void#inDataset": {
+        "uri": "http://aims.fao.org/aos/agrovoc/void.ttl#Agrovoc"
+      },
+      "skos:notation": {
+        "type": "http://aims.fao.org/aos/agrovoc/AgrovocCode",
+        "value": "1331561600472"
+      },
+      "http://www.w3.org/2008/05/skos-xl#literalForm": {
+        "lang": "tr",
+        "value": "faaliyet"
+      }
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/xl_tr_1331561625299",
+      "type": "http://www.w3.org/2008/05/skos-xl#Label",
+      "dct:created": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2012-03-12T22:13:45Z"
+      },
+      "dct:modified": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2017-09-22T14:09:06Z"
+      },
+      "http://rdfs.org/ns/void#inDataset": {
+        "uri": "http://aims.fao.org/aos/agrovoc/void.ttl#Agrovoc"
+      },
+      "skos:notation": {
+        "type": "http://aims.fao.org/aos/agrovoc/AgrovocCode",
+        "value": "1331561625299"
+      },
+      "http://www.w3.org/2008/05/skos-xl#literalForm": {
+        "lang": "tr",
+        "value": "aktivite"
+      }
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/xl_uk_1336988245814",
+      "type": "http://www.w3.org/2008/05/skos-xl#Label",
+      "dct:created": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2012-05-14T17:37:25Z"
+      },
+      "dct:modified": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2013-08-30T17:19:36Z"
+      },
+      "http://rdfs.org/ns/void#inDataset": {
+        "uri": "http://aims.fao.org/aos/agrovoc/void.ttl#Agrovoc"
+      },
+      "skos:notation": {
+        "type": "http://aims.fao.org/aos/agrovoc/AgrovocCode",
+        "value": "330834"
+      },
+      "http://www.w3.org/2008/05/skos-xl#literalForm": {
+        "lang": "uk",
+        "value": "діяльність"
+      }
+    },
+    {
+      "uri": "http://aims.fao.org/aos/agrovoc/xl_zh_1303260548028",
+      "type": "http://www.w3.org/2008/05/skos-xl#Label",
+      "dct:created": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2011-04-20T08:49:08Z"
+      },
+      "dct:modified": {
+        "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "value": "2024-02-28T16:28:32"
+      },
+      "http://rdfs.org/ns/void#inDataset": {
+        "uri": "http://aims.fao.org/aos/agrovoc/void.ttl#Agrovoc"
+      },
+      "skos:notation": {
+        "type": "http://aims.fao.org/aos/agrovoc/AgrovocCode",
+        "value": "330834"
+      },
+      "http://www.w3.org/2008/05/skos-xl#literalForm": {
+        "lang": "zh",
+        "value": "活动"
+      }
+    },
+    {
+      "uri": "skos:prefLabel",
+      "rdfs:comment": {
+        "lang": "en",
+        "value": "A resource has no more than one value of skos:prefLabel per language tag."
+      }
+    }
+  ]
 }


### PR DESCRIPTION
This PR introduces a new alternative way of mapping results from connected services, based on JsonPath queries.

The necessity for this enhancement origins from the requirement to include `skos:definitions` from SKOSMOS endpoints.

The issue that this PR solves is that SKOSMOS's `/data` endpoint returns concept descriptions in a graph-based structure with `skos:definition`s residing in a node that is not directly linked to the concept's node, requiring relational "joins" or cross-referencing between different arrays, which our tree-based selection model did not support.

The new way of mapping introduced with this PR allows this kind of relational join by using a query language that is an extension of JsonPath and allows mappings in the form of

```yaml
    label: "$.graph[?(@.uri=='{resourceUri}')].prefLabel[?(@.lang=='en')].value"
    iri: "$.graph[?(@.uri=='{resourceUri}')].uri"
    synonyms: "$.graph[?(@.uri=='{resourceUri}')].altLabel[?(@.lang=='en')].value"
    descriptions: "$.graph[?(@.uri in $.graph[?(@.uri=='{resourceUri}')]['skos:definition'][*].uri)]['http://www.w3.org/1999/02/22-rdf-syntax-ns#value'][?(@.lang=='en')].value"
    ontologyIri: "$.graph[?(@.uri=='{resourceUri}')].inScheme.uri"
    type: "$.graph[?(@.uri=='{resourceUri}')].type"
    hasChildren: "$.graph[?(@.uri=='{resourceUri}')].narrower"
```

The result of such a JsonPath-like query is always an array.

The values are mapped to our internal property types as follows:

- array: the resulting array is used
- string: the first element's (if present) string representation is used (null otherwise)
- boolean: if the array is present and contains one or more elements, the property will be set to `true`, otherwise to `false`.

This PR is based on `fix/182-named-query-params` and included in a PR stack with #199 as it is based on the recent changes therein.

Resolves #202