### PR TITLE
Feat/add skosmos source

### DIFF
--- a/src/main/java/org/semantics/apigateway/config/EndpointParameterMapping.java
+++ b/src/main/java/org/semantics/apigateway/config/EndpointParameterMapping.java
@@ -20,7 +20,7 @@ public class EndpointParameterMapping {
   public enum Type {
     path(x -> x.value),
     string(x -> x.name + "=" + x.value),
-    stringAsterisk(x -> x.name + "*"),
+    stringAsterisk(x -> x.name + "=" + x.value + "*"),
     integer(x -> x.name + "=" + x.value),
     commaList(x -> x.name + "=" + String.join(",", x.value.split(","))),
     pipeList(x -> x.name + "=" + String.join("|", x.value.split(","))),

--- a/src/main/resources/backend_types/skosmos.yml
+++ b/src/main/resources/backend_types/skosmos.yml
@@ -41,6 +41,7 @@ endpoints:
 
   concepts:
     path: /{artefact}/label
+    caseInsensitive: false
     parameters:
       artefact:
         name: acronym
@@ -50,6 +51,7 @@ endpoints:
 
   concept_details:
     path: /{artefact}/label
+    caseInsensitive: false
     parameters:
       artefact:
         name: acronym
@@ -62,6 +64,7 @@ endpoints:
 
   resource_details:
     path: /{artefact}
+    caseInsensitive: false
     responseMapping:
       label: id
       iri: conceptschemes->uri|uri

--- a/src/main/resources/databases.json
+++ b/src/main/resources/databases.json
@@ -56,6 +56,11 @@
       "url": "https://agrovoc.fao.org/browse/rest/v1"
     },
     {
+      "type": "skosmos",
+      "name": "zbmed-skosmos",
+      "url": "https://semanticlookup.zbmed.de/skosmos/rest/v1"
+    },
+    {
       "type": "gnd",
       "name": "gnd",
       "url": "https://lobid.org"


### PR DESCRIPTION
- feat: add ZBMED Skosmos source (closes #207)
- fix: Skosmos vocabulary id sensitivity (closes #209): The vocabulary ID (e.g. VOC4CAT) in the Skosmos request URL is case-sensitive.
- fix: endpoint parameter mapping (closes #208): The query parameter value is not added when the parameters are constructed, resulting in the query value being missing from the request

